### PR TITLE
Add Express metrics server for Raspberry Pi

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,47 @@
+# Raspberry Pi Metrics Server
+
+This lightweight Express server exposes REST endpoints that report CPU load, memory usage, disk usage, and temperature for a Raspberry Pi 5.
+
+## Requirements
+
+- Node.js 18 or later (preinstalled on Raspberry Pi OS Bookworm)
+- npm (included with Node.js)
+
+## Installation
+
+```bash
+cd /path/to/RaspberryPiServer2/server
+npm install
+```
+
+## Usage
+
+Start the metrics API:
+
+```bash
+node index.js
+```
+
+The server listens on port `3001` by default. Override the port or sampling behaviour with environment variables:
+
+- `PORT` – HTTP port to listen on (default: `3001`)
+- `SAMPLE_INTERVAL_MS` – Interval between metric samples stored in history (default: `5000` ms)
+- `MAX_METRIC_SAMPLES` – Maximum number of samples kept in the ring buffer (default: `1000`)
+
+### API Endpoints
+
+- `GET /api/metrics/current` – Returns a fresh snapshot collected on request.
+- `GET /api/metrics/history` – Returns the in-memory history of recent samples.
+
+## Keeping the server running
+
+To keep the service running in the background after reboot, you can use a process manager such as [PM2](https://pm2.keymetrics.io/):
+
+```bash
+sudo npm install -g pm2
+pm2 start index.js --name raspi-metrics
+pm2 save
+pm2 startup
+```
+
+Alternatively, create a `systemd` service that runs `node /path/to/RaspberryPiServer2/server/index.js` at boot.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,92 @@
+import express from 'express';
+import cors from 'cors';
+import si from 'systeminformation';
+
+const PORT = process.env.PORT || 3001;
+const SAMPLE_INTERVAL_MS = Number.parseInt(process.env.SAMPLE_INTERVAL_MS ?? '5000', 10);
+const MAX_SAMPLES = Number.parseInt(process.env.MAX_METRIC_SAMPLES ?? '1000', 10);
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const metricsHistory = [];
+
+function addToHistory(sample) {
+  metricsHistory.push(sample);
+  if (metricsHistory.length > MAX_SAMPLES) {
+    metricsHistory.splice(0, metricsHistory.length - MAX_SAMPLES);
+  }
+}
+
+async function gatherMetrics() {
+  const [load, memory, disks, temperature] = await Promise.all([
+    si.currentLoad(),
+    si.mem(),
+    si.fsSize(),
+    si.cpuTemperature()
+  ]);
+
+  const totalDiskBytes = disks.reduce((total, disk) => total + disk.size, 0);
+  const usedDiskBytes = disks.reduce((total, disk) => total + disk.used, 0);
+
+  return {
+    timestamp: new Date().toISOString(),
+    cpu: {
+      load: load.currentLoad,
+      cores: load.cpus?.map((cpu) => cpu.load) ?? []
+    },
+    memory: {
+      total: memory.total,
+      available: memory.available,
+      used: memory.total - memory.available,
+      free: memory.free
+    },
+    disk: {
+      total: totalDiskBytes,
+      used: usedDiskBytes,
+      available: totalDiskBytes - usedDiskBytes
+    },
+    temperature: {
+      main: temperature.main,
+      cores: temperature.cores,
+      max: temperature.max
+    }
+  };
+}
+
+async function sampleAndStoreMetrics() {
+  try {
+    const sample = await gatherMetrics();
+    addToHistory(sample);
+  } catch (error) {
+    console.error('Failed to gather system metrics:', error);
+  }
+}
+
+// Prime the history buffer with an initial reading so history is never empty.
+sampleAndStoreMetrics();
+
+setInterval(sampleAndStoreMetrics, SAMPLE_INTERVAL_MS);
+
+app.get('/api/metrics/current', async (req, res) => {
+  try {
+    const metrics = await gatherMetrics();
+    res.json(metrics);
+  } catch (error) {
+    console.error('Error retrieving current metrics:', error);
+    res.status(500).json({ error: 'Failed to retrieve current metrics' });
+  }
+});
+
+app.get('/api/metrics/history', (req, res) => {
+  res.json({
+    intervalMs: SAMPLE_INTERVAL_MS,
+    maxSamples: MAX_SAMPLES,
+    samples: metricsHistory
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Metrics server listening on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "raspberrypi-metrics-server",
+  "version": "1.0.0",
+  "description": "REST API for exposing Raspberry Pi system metrics",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "systeminformation": "^5.23.10"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Node.js server that collects CPU, memory, disk, and temperature metrics using systeminformation
- expose current metrics and historical samples via Express endpoints with CORS enabled
- document installation, configuration, and process management options for running on Raspberry Pi 5

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b7eeb7f48331b8cfffd13920229e