### PR TITLE
feat: refresh dashboard data every second

### DIFF
--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -84,6 +84,8 @@ const metricCards = computed(() => [
   },
 ])
 
+const REFRESH_INTERVAL_MS = 1000
+
 let currentIntervalId
 let historyIntervalId
 
@@ -266,8 +268,8 @@ onMounted(async () => {
   await Promise.all([fetchHistoryMetrics(), fetchCurrentMetrics()])
   renderChart()
 
-  currentIntervalId = window.setInterval(fetchCurrentMetrics, 5000)
-  historyIntervalId = window.setInterval(fetchHistoryMetrics, 30000)
+  currentIntervalId = window.setInterval(fetchCurrentMetrics, REFRESH_INTERVAL_MS)
+  historyIntervalId = window.setInterval(fetchHistoryMetrics, REFRESH_INTERVAL_MS)
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- add a shared refresh interval constant on the dashboard view
- update scheduled updates to refresh both current and historical metrics every second

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6e069369883319111e4c835f1a906