### PR TITLE
Fix dashboard chart initialization and polling

### DIFF
--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -31,13 +31,14 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import axios from 'axios'
 import {
   CategoryScale,
   Chart,
   Filler,
   Legend,
+  LineController,
   LineElement,
   LinearScale,
   PointElement,
@@ -45,7 +46,17 @@ import {
   Tooltip,
 } from 'chart.js'
 
-Chart.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+Chart.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineController,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  Filler
+)
 
 const chartCanvas = ref(null)
 const chartInstance = ref(null)
@@ -233,9 +244,8 @@ const renderChart = () => {
   }
 
   if (chartInstance.value) {
-    chartInstance.value.data = chartData
-    chartInstance.value.update()
-    return
+    chartInstance.value.destroy()
+    chartInstance.value = null
   }
 
   chartInstance.value = new Chart(ctx, {
@@ -283,10 +293,6 @@ const renderChart = () => {
     },
   })
 }
-
-watch(historyMetrics, () => {
-  renderChart()
-})
 
 onMounted(async () => {
   await Promise.all([fetchHistoryMetrics(), fetchCurrentMetrics()])


### PR DESCRIPTION
## Summary
- register the Chart.js LineController so the history chart can be constructed without runtime errors
- rebuild the chart instance on each refresh and remove the redundant watcher to keep polling updates running reliably

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6e92eb8988331ba2268cfe3a1f360