### PR TITLE
Enhance Shelly control for multiple devices

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,10 +1,49 @@
 <script setup>
+import { computed, ref } from 'vue'
 import Dashboard from './views/Dashboard.vue'
+import ShellyControl from './views/ShellyControl.vue'
+
+const tabs = [
+  { id: 'dashboard', label: 'System Metrics' },
+  { id: 'shelly', label: 'Shelly Device' }
+]
+
+const activeTab = ref(tabs[0].id)
+
+const selectTab = (tabId) => {
+  activeTab.value = tabId
+}
+
+const activeTabComponent = computed(() =>
+  activeTab.value === 'shelly' ? ShellyControl : Dashboard
+)
+
+const activeTabLabel = computed(
+  () => tabs.find((tab) => tab.id === activeTab.value)?.label ?? ''
+)
 </script>
 
 <template>
   <main class="app-shell">
-    <Dashboard />
+    <header class="app-header">
+      <h1 class="app-title">Raspberry Pi Control Center</h1>
+      <nav class="tab-navigation" aria-label="Primary">
+        <button
+          v-for="tab in tabs"
+          :key="tab.id"
+          type="button"
+          class="tab-button"
+          :class="{ 'tab-button--active': tab.id === activeTab }"
+          @click="selectTab(tab.id)"
+        >
+          {{ tab.label }}
+        </button>
+      </nav>
+    </header>
+
+    <section class="tab-panel" role="tabpanel" :aria-label="activeTabLabel">
+      <component :is="activeTabComponent" />
+    </section>
   </main>
 </template>
 
@@ -12,11 +51,89 @@ import Dashboard from './views/Dashboard.vue'
 .app-shell {
   min-height: 100vh;
   background: linear-gradient(180deg, #eef2ff 0%, #f8fafc 100%);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 2rem 1.5rem 1rem;
+  text-align: center;
+}
+
+.app-title {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.75rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #0f172a;
+}
+
+.tab-navigation {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.tab-button {
+  border: none;
+  border-radius: 9999px;
+  padding: 0.65rem 1.75rem;
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+}
+
+.tab-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px -16px rgba(15, 23, 42, 0.65);
+}
+
+.tab-button--active {
+  background: #1d4ed8;
+  color: #f8fafc;
+  box-shadow: 0 12px 22px -16px rgba(29, 78, 216, 0.8);
+}
+
+.tab-button:disabled,
+.tab-button--active:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.tab-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 3rem;
 }
 
 @media (prefers-color-scheme: dark) {
   .app-shell {
     background: radial-gradient(circle at top, #1e293b 0%, #020617 100%);
+  }
+
+  .app-title {
+    color: #f8fafc;
+  }
+
+  .tab-button {
+    background: rgba(148, 163, 184, 0.15);
+    color: #e2e8f0;
+  }
+
+  .tab-button--active {
+    background: #2563eb;
+    color: #f8fafc;
+    box-shadow: 0 12px 22px -16px rgba(37, 99, 235, 0.9);
   }
 }
 </style>

--- a/client/src/views/ShellyControl.vue
+++ b/client/src/views/ShellyControl.vue
@@ -1,0 +1,803 @@
+<template>
+  <div class="shelly-control">
+    <header class="control-header">
+      <div class="header-text">
+        <h2>Panel oświetlenia Shelly</h2>
+        <p>Steruj i monitoruj inteligentne światła w czasie rzeczywistym.</p>
+      </div>
+      <div class="device-selector" v-if="devices.length">
+        <label>
+          <span>Urządzenie</span>
+          <select v-model="selectedDeviceId" :disabled="isLoadingDevices || isBusy">
+            <option v-for="device in devices" :key="device.id" :value="device.id">
+              {{ device.name }}
+            </option>
+          </select>
+        </label>
+        <p class="device-address" v-if="selectedDevice">Adres IP: {{ deviceAddress }}</p>
+      </div>
+    </header>
+
+    <p v-if="isLoadingDevices" class="helper-text">Wyszukiwanie urządzeń Shelly…</p>
+    <p v-else-if="deviceLoadError" class="error-message">{{ deviceLoadError }}</p>
+
+    <section v-if="selectedDevice" class="power-section">
+      <button
+        type="button"
+        class="power-button"
+        :class="powerButtonClasses"
+        :aria-pressed="isLightOn"
+        :disabled="isBusy"
+        @click="handlePowerButtonClick"
+      >
+        <svg class="power-button__icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M12 2a1 1 0 0 1 1 1v8a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1Zm-5.657 4.343a1 1 0 0 1 1.414 0A7 7 0 1 1 17.657 6.343a1 1 0 0 1 1.414-1.414 9 9 0 1 1-12.728 0 1 1 0 0 1 1.414 1.414Z"
+            fill="currentColor"
+          />
+        </svg>
+        <span class="power-button__label">{{ powerButtonLabel }}</span>
+        <span class="power-button__state">{{ powerButtonState }}</span>
+      </button>
+      <div class="power-meta">
+        <p>{{ statusSummary }}</p>
+        <p v-if="formattedLastUpdated">Ostatnia aktualizacja: {{ formattedLastUpdated }}</p>
+        <button
+          type="button"
+          class="refresh-button"
+          :disabled="isBusy"
+          @click="refreshStatus()"
+        >
+          Odśwież teraz
+        </button>
+      </div>
+    </section>
+
+    <section v-if="selectedDevice" class="status-card">
+      <h3>Parametry urządzenia</h3>
+      <div class="status-grid">
+        <div class="status-tile">
+          <span class="status-label">Stan przekaźnika</span>
+          <span :class="['relay-pill', relayStateClass]">{{ relayStateLabel }}</span>
+        </div>
+        <div class="status-tile" v-if="meterDetails?.power !== null">
+          <span class="status-label">Pobór mocy</span>
+          <span class="status-value">{{ meterDetails.power.toFixed(1) }} W</span>
+        </div>
+        <div class="status-tile" v-if="meterDetails?.voltage !== null">
+          <span class="status-label">Napięcie</span>
+          <span class="status-value">{{ meterDetails.voltage.toFixed(1) }} V</span>
+        </div>
+        <div class="status-tile" v-if="meterDetails?.total !== null">
+          <span class="status-label">Zużycie całkowite</span>
+          <span class="status-value">{{ meterDetails.total.toFixed(1) }} Wh</span>
+        </div>
+        <div class="status-tile" v-if="relayDetails.source">
+          <span class="status-label">Ostatnia akcja</span>
+          <span class="status-value">{{ relayDetails.source }}</span>
+        </div>
+        <div class="status-tile" v-if="wifiDetails">
+          <span class="status-label">Wi-Fi</span>
+          <span class="status-value">
+            <span v-if="wifiDetails.ssid">{{ wifiDetails.ssid }}</span>
+            <span v-if="wifiDetails.ssid && wifiDetails.ip" aria-hidden="true"> · </span>
+            <span v-if="wifiDetails.ip">{{ wifiDetails.ip }}</span>
+            <span v-if="wifiDetails.rssi !== null" aria-hidden="true"> · </span>
+            <span v-if="wifiDetails.rssi !== null">{{ wifiDetails.rssi }} dBm</span>
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <section v-if="selectedDevice && (deviceInfo || meterDetails)" class="details-card">
+      <h3>Szczegóły techniczne</h3>
+      <div class="details-grid">
+        <div v-if="deviceInfo?.name" class="detail-item">
+          <span class="detail-label">Nazwa</span>
+          <span class="detail-value">{{ deviceInfo.name }}</span>
+        </div>
+        <div v-if="deviceInfo?.model" class="detail-item">
+          <span class="detail-label">Model</span>
+          <span class="detail-value">{{ deviceInfo.model }}</span>
+        </div>
+        <div v-if="deviceInfo?.firmware" class="detail-item">
+          <span class="detail-label">Firmware</span>
+          <span class="detail-value">{{ deviceInfo.firmware }}</span>
+        </div>
+        <div v-if="meterDetails?.energy !== null" class="detail-item">
+          <span class="detail-label">Energia dzisiaj</span>
+          <span class="detail-value">{{ meterDetails.energy.toFixed(1) }} Wh</span>
+        </div>
+      </div>
+    </section>
+
+    <details v-if="selectedDevice && shellyStatus" class="raw-section">
+      <summary>Surowa odpowiedź urządzenia</summary>
+      <pre>{{ formattedShellyStatus }}</pre>
+    </details>
+
+    <p v-if="helperMessage" class="helper-text">{{ helperMessage }}</p>
+    <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+  </div>
+</template>
+
+<script setup>
+import axios from 'axios'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const SHELLY_REFRESH_INTERVAL_MS = 2500
+
+const devices = ref([])
+const isLoadingDevices = ref(false)
+const deviceLoadError = ref('')
+const selectedDeviceId = ref('')
+
+const shellyStatus = ref(null)
+const isLoading = ref(false)
+const isSilentRefreshing = ref(false)
+const isToggling = ref(false)
+const errorMessage = ref('')
+const lastRefreshedAt = ref(null)
+let refreshTimerId = null
+
+const selectedDevice = computed(() =>
+  devices.value.find((device) => device.id === selectedDeviceId.value) ?? null
+)
+
+const deviceAddress = computed(() => selectedDevice.value?.address ?? '')
+
+const isBusy = computed(
+  () => isLoading.value || isToggling.value || isSilentRefreshing.value
+)
+
+const toBooleanOrNull = (value) => {
+  if (typeof value === 'boolean') return value
+  if (value === 1 || value === '1') return true
+  if (value === 0 || value === '0') return false
+  return null
+}
+
+const relayDetails = computed(() => {
+  const relay =
+    shellyStatus.value?.relays?.[0] ??
+    shellyStatus.value?.switch?.[0] ??
+    shellyStatus.value?.switches?.[0] ??
+    null
+
+  if (!relay) {
+    return {
+      isOn: null,
+      source: '',
+      timerActive: false
+    }
+  }
+
+  const possibleStates = [relay.ison, relay.output, relay.state, relay.value]
+  const isOn = possibleStates.map(toBooleanOrNull).find((value) => value !== null) ?? null
+
+  return {
+    isOn,
+    source: relay.source ?? relay.apower_source ?? '',
+    timerActive: relay.has_timer === true || Number(relay.timer_duration) > 0
+  }
+})
+
+const isLightOn = computed(() => relayDetails.value.isOn === true)
+
+const relayStateLabel = computed(() => {
+  if (relayDetails.value.isOn === null) return 'Nieznany'
+  return relayDetails.value.isOn ? 'Włączone' : 'Wyłączone'
+})
+
+const relayStateClass = computed(() => {
+  if (relayDetails.value.isOn === null) return 'relay-pill--unknown'
+  return relayDetails.value.isOn ? 'relay-pill--on' : 'relay-pill--off'
+})
+
+const meterDetails = computed(() => {
+  const meter =
+    shellyStatus.value?.meters?.[0] ??
+    shellyStatus.value?.emeters?.[0] ??
+    shellyStatus.value?.pm1_voltages?.[0] ??
+    null
+
+  if (!meter) {
+    return null
+  }
+
+  const power = Number.isFinite(meter.power) ? meter.power : null
+  const total = Number.isFinite(meter.total) ? meter.total : null
+  const energy = Number.isFinite(meter.energy) ? meter.energy : null
+  const voltage = Number.isFinite(meter.voltage) ? meter.voltage : null
+
+  if ([power, total, energy, voltage].every((value) => value === null)) {
+    return null
+  }
+
+  return { power, total, energy, voltage }
+})
+
+const wifiDetails = computed(() => {
+  const wifi =
+    shellyStatus.value?.wifi_sta ??
+    shellyStatus.value?.wifi_sta1 ??
+    shellyStatus.value?.wifi ??
+    null
+
+  if (!wifi) {
+    return null
+  }
+
+  const ssid = wifi.ssid ?? wifi.ssid1 ?? ''
+  const ip = wifi.ip ?? wifi.ipv4 ?? wifi.ipv6 ?? ''
+  const rssi = Number.isFinite(wifi.rssi) ? wifi.rssi : null
+
+  if (!ssid && !ip && rssi === null) {
+    return null
+  }
+
+  return { ssid, ip, rssi }
+})
+
+const deviceInfo = computed(() => {
+  if (!shellyStatus.value) {
+    return null
+  }
+
+  const name = shellyStatus.value.device?.name ?? shellyStatus.value.name ?? ''
+  const model = shellyStatus.value.device?.type ?? shellyStatus.value.model ?? ''
+  const firmware = shellyStatus.value.fw ?? shellyStatus.value.firmware ?? ''
+
+  if (!name && !model && !firmware) {
+    return null
+  }
+
+  return { name, model, firmware }
+})
+
+const formattedLastUpdated = computed(() => {
+  if (!lastRefreshedAt.value) return ''
+  const date = new Date(lastRefreshedAt.value)
+  return Number.isNaN(date.getTime()) ? '' : date.toLocaleString()
+})
+
+const formattedShellyStatus = computed(() => {
+  if (!shellyStatus.value) return ''
+  return JSON.stringify(shellyStatus.value, null, 2)
+})
+
+const powerButtonLabel = computed(() => {
+  if (!selectedDevice.value) return 'Brak urządzenia'
+  if (isBusy.value) return 'Przetwarzanie…'
+  if (relayDetails.value.isOn === null) return 'Sprawdź stan'
+  return relayDetails.value.isOn ? 'Wyłącz światło' : 'Włącz światło'
+})
+
+const powerButtonState = computed(() => {
+  if (!selectedDevice.value) return ''
+  if (relayDetails.value.isOn === null) return 'Stan nieznany'
+  return relayDetails.value.isOn ? 'Światło jest włączone' : 'Światło jest wyłączone'
+})
+
+const statusSummary = computed(() => {
+  if (!selectedDevice.value) return ''
+  if (isBusy.value) return 'Aktualizuję stan urządzenia…'
+  if (relayDetails.value.isOn === null) return 'Oczekiwanie na dane z urządzenia Shelly.'
+  const deviceName = selectedDevice.value.name
+  return relayDetails.value.isOn
+    ? `Światło „${deviceName}” świeci.`
+    : `Światło „${deviceName}” jest wyłączone.`
+})
+
+const powerButtonClasses = computed(() => ({
+  'power-button--on': relayDetails.value.isOn === true,
+  'power-button--off': relayDetails.value.isOn === false,
+  'power-button--unknown': relayDetails.value.isOn === null,
+  'power-button--busy': isBusy.value
+}))
+
+const helperMessage = computed(() => {
+  if (isToggling.value) {
+    return 'Wysyłam polecenie do urządzenia…'
+  }
+  if (isLoading.value) {
+    return 'Ładuję najnowszy status urządzenia Shelly…'
+  }
+  if (isSilentRefreshing.value) {
+    return 'Odświeżam stan światła w tle…'
+  }
+  return ''
+})
+
+const stopRefreshLoop = () => {
+  if (typeof window === 'undefined') return
+  if (refreshTimerId) {
+    window.clearInterval(refreshTimerId)
+    refreshTimerId = null
+  }
+}
+
+const startRefreshLoop = () => {
+  stopRefreshLoop()
+  if (typeof window === 'undefined' || !selectedDevice.value) return
+  refreshTimerId = window.setInterval(() => {
+    refreshStatus({ silent: true })
+  }, SHELLY_REFRESH_INTERVAL_MS)
+}
+
+const refreshStatus = async ({ silent = false } = {}) => {
+  if (!selectedDevice.value) {
+    return
+  }
+
+  if (silent) {
+    if (isSilentRefreshing.value || isLoading.value || isToggling.value) {
+      return
+    }
+    isSilentRefreshing.value = true
+  } else {
+    if (isLoading.value) {
+      return
+    }
+    isLoading.value = true
+    errorMessage.value = ''
+  }
+
+  try {
+    const { data } = await axios.get(`/api/shelly/${selectedDevice.value.id}/status`)
+    shellyStatus.value = data
+    lastRefreshedAt.value = new Date().toISOString()
+    errorMessage.value = ''
+  } catch (error) {
+    console.error('Failed to retrieve Shelly status', error)
+    const message =
+      'Nie udało się pobrać stanu urządzenia Shelly. Sprawdź połączenie i spróbuj ponownie.'
+    if (silent) {
+      if (!errorMessage.value) {
+        errorMessage.value = message
+      }
+    } else {
+      errorMessage.value = message
+    }
+  } finally {
+    if (silent) {
+      isSilentRefreshing.value = false
+    } else {
+      isLoading.value = false
+    }
+  }
+}
+
+const sendRelayCommand = async (turn) => {
+  if (!selectedDevice.value) return
+  if (isToggling.value || isLoading.value) {
+    return
+  }
+
+  isToggling.value = true
+  errorMessage.value = ''
+
+  try {
+    await axios.post(`/api/shelly/${selectedDevice.value.id}/relay`, { turn })
+    await refreshStatus({ silent: true })
+  } catch (error) {
+    console.error('Failed to update Shelly relay state', error)
+    errorMessage.value = 'Nie udało się zmienić stanu światła.'
+  } finally {
+    isToggling.value = false
+  }
+}
+
+const handlePowerButtonClick = async () => {
+  if (!selectedDevice.value) return
+  if (relayDetails.value.isOn === null) {
+    await refreshStatus()
+    return
+  }
+
+  const desiredAction = relayDetails.value.isOn ? 'off' : 'on'
+  await sendRelayCommand(desiredAction)
+}
+
+const loadDevices = async () => {
+  isLoadingDevices.value = true
+  deviceLoadError.value = ''
+
+  try {
+    const { data } = await axios.get('/api/shelly/devices')
+    const list = Array.isArray(data?.devices) ? data.devices : []
+    devices.value = list
+
+    if (!list.length) {
+      deviceLoadError.value = 'Nie znaleziono skonfigurowanych urządzeń Shelly.'
+      selectedDeviceId.value = ''
+      return
+    }
+
+    if (!selectedDeviceId.value || !list.some((device) => device.id === selectedDeviceId.value)) {
+      selectedDeviceId.value = list[0].id
+    }
+  } catch (error) {
+    console.error('Failed to load Shelly device list', error)
+    deviceLoadError.value = 'Nie udało się pobrać listy urządzeń Shelly.'
+    devices.value = []
+    selectedDeviceId.value = ''
+  } finally {
+    isLoadingDevices.value = false
+  }
+}
+
+watch(selectedDeviceId, async (newId, oldId) => {
+  if (!newId) {
+    shellyStatus.value = null
+    stopRefreshLoop()
+    return
+  }
+
+  if (newId !== oldId) {
+    shellyStatus.value = null
+    errorMessage.value = ''
+    await refreshStatus()
+    startRefreshLoop()
+  }
+})
+
+onMounted(async () => {
+  await loadDevices()
+})
+
+onBeforeUnmount(() => {
+  stopRefreshLoop()
+})
+</script>
+
+<style scoped>
+.shelly-control {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.control-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.header-text h2 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.5rem);
+  font-weight: 700;
+}
+
+.header-text p {
+  margin: 0.35rem 0 0;
+  color: #4b5563;
+}
+
+.device-selector {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+  text-align: right;
+}
+
+.device-selector label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.device-selector select {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+}
+
+.device-address {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.power-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.power-button {
+  position: relative;
+  width: min(60vw, 220px);
+  height: min(60vw, 220px);
+  border-radius: 50%;
+  border: none;
+  background: radial-gradient(circle at top, #1f2937, #0f172a 70%);
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  cursor: pointer;
+  box-shadow: 0 20px 45px -25px rgba(15, 23, 42, 0.9);
+  transition: transform 200ms ease, box-shadow 200ms ease, filter 200ms ease;
+}
+
+.power-button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.35);
+}
+
+.power-button:not(:disabled):hover {
+  transform: translateY(-4px);
+  box-shadow: 0 25px 60px -30px rgba(59, 130, 246, 0.7);
+}
+
+.power-button__icon {
+  width: 70px;
+  height: 70px;
+}
+
+.power-button__label {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.power-button__state {
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.power-button--on {
+  background: radial-gradient(circle at top, rgba(34, 197, 94, 0.9), rgba(6, 95, 70, 0.95));
+  box-shadow: 0 25px 70px -25px rgba(34, 197, 94, 0.75);
+  animation: powerPulse 2.2s ease-in-out infinite;
+}
+
+.power-button--off {
+  background: radial-gradient(circle at top, rgba(226, 232, 240, 0.12), rgba(15, 23, 42, 0.95));
+}
+
+.power-button--unknown {
+  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.4), rgba(51, 65, 85, 0.95));
+}
+
+.power-button--busy {
+  animation: none;
+  box-shadow: 0 10px 25px -18px rgba(15, 23, 42, 0.9);
+}
+
+@keyframes powerPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 20px rgba(34, 197, 94, 0.45), 0 0 45px rgba(34, 197, 94, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 30px rgba(34, 197, 94, 0.7), 0 0 70px rgba(34, 197, 94, 0.6);
+  }
+}
+
+.power-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: center;
+  color: #334155;
+}
+
+.refresh-button {
+  align-self: center;
+  border: none;
+  border-radius: 9999px;
+  padding: 0.5rem 1.5rem;
+  background: #1d4ed8;
+  color: #f8fafc;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.refresh-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.refresh-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px -16px rgba(29, 78, 216, 0.8);
+}
+
+.status-card,
+.details-card,
+.raw-section {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.4);
+}
+
+.status-card h3,
+.details-card h3 {
+  margin: 0 0 1.25rem;
+  font-size: 1.35rem;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.status-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.85rem;
+  border-radius: 0.85rem;
+  background: rgba(241, 245, 249, 0.65);
+}
+
+.status-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.status-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.relay-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 9999px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.relay-pill--on {
+  background: rgba(34, 197, 94, 0.15);
+  color: #166534;
+}
+
+.relay-pill--off {
+  background: rgba(239, 68, 68, 0.15);
+  color: #991b1b;
+}
+
+.relay-pill--unknown {
+  background: rgba(148, 163, 184, 0.2);
+  color: #475569;
+}
+
+.details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.85rem;
+  border-radius: 0.85rem;
+  background: rgba(241, 245, 249, 0.65);
+}
+
+.detail-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.detail-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.raw-section summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: #0f172a;
+}
+
+.raw-section pre {
+  margin: 0;
+  overflow-x: auto;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.helper-text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #4b5563;
+  text-align: center;
+}
+
+.error-message {
+  margin: 0;
+  color: #b91c1c;
+  font-weight: 600;
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .shelly-control {
+    padding: 1.5rem;
+  }
+
+  .device-selector {
+    align-items: flex-start;
+    text-align: left;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .header-text p,
+  .device-address,
+  .power-meta,
+  .status-label,
+  .status-value,
+  .detail-label,
+  .detail-value,
+  .helper-text,
+  .error-message {
+    color: inherit;
+  }
+
+  .device-selector select {
+    background: rgba(15, 23, 42, 0.6);
+    color: #f8fafc;
+    border-color: rgba(148, 163, 184, 0.35);
+  }
+
+  .status-card,
+  .details-card,
+  .raw-section {
+    background: rgba(15, 23, 42, 0.85);
+    box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.9);
+  }
+
+  .status-tile,
+  .detail-item {
+    background: rgba(30, 41, 59, 0.6);
+  }
+
+  .raw-section pre {
+    background: #020617;
+    color: #f1f5f9;
+  }
+
+  .refresh-button {
+    background: #2563eb;
+  }
+}
+</style>

--- a/server/index.js
+++ b/server/index.js
@@ -5,12 +5,127 @@ import si from 'systeminformation';
 const PORT = Number(process.env.PORT) || 3000;
 const SAMPLE_INTERVAL_MS = Number.parseInt(process.env.SAMPLE_INTERVAL_MS ?? '1000', 10);
 const MAX_SAMPLES = Number.parseInt(process.env.MAX_METRIC_SAMPLES ?? '1000', 10);
+const SHELLY_BASE_URL = process.env.SHELLY_BASE_URL ?? 'http://192.168.0.122/';
+const SHELLY_TIMEOUT_MS = Number.parseInt(process.env.SHELLY_TIMEOUT_MS ?? '5000', 10);
+const SHELLY_DEFAULT_DEVICE_ID = process.env.SHELLY_DEFAULT_DEVICE_ID ?? 'swiatlo-michal-pokoj';
+const SHELLY_DEFAULT_DEVICE_NAME =
+  process.env.SHELLY_DEFAULT_DEVICE_NAME ?? 'Światło Michał Pokój';
+
+function normalizeBaseUrl(url) {
+  if (!url) return '';
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+function parseShellyDevices() {
+  const raw = process.env.SHELLY_DEVICES;
+
+  if (!raw) {
+    return [
+      {
+        id: SHELLY_DEFAULT_DEVICE_ID,
+        name: SHELLY_DEFAULT_DEVICE_NAME,
+        host: normalizeBaseUrl(SHELLY_BASE_URL)
+      }
+    ];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      throw new Error('SHELLY_DEVICES must be a JSON array');
+    }
+
+    const sanitized = parsed
+      .map((device) => ({
+        id: String(device.id ?? '').trim(),
+        name: String(device.name ?? '').trim(),
+        host: normalizeBaseUrl(device.host ?? device.baseUrl ?? '')
+      }))
+      .filter((device) => device.id && device.name && device.host);
+
+    return sanitized.length
+      ? sanitized
+      : [
+          {
+            id: SHELLY_DEFAULT_DEVICE_ID,
+            name: SHELLY_DEFAULT_DEVICE_NAME,
+            host: normalizeBaseUrl(SHELLY_BASE_URL)
+          }
+        ];
+  } catch (error) {
+    console.warn('Failed to parse SHELLY_DEVICES environment variable:', error);
+    return [
+      {
+        id: SHELLY_DEFAULT_DEVICE_ID,
+        name: SHELLY_DEFAULT_DEVICE_NAME,
+        host: normalizeBaseUrl(SHELLY_BASE_URL)
+      }
+    ];
+  }
+}
+
+const shellyDevices = parseShellyDevices();
+const shellyDeviceMap = new Map(shellyDevices.map((device) => [device.id, device]));
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
 const metricsHistory = [];
+
+function getShellyDevice(deviceId) {
+  const device = shellyDeviceMap.get(deviceId);
+  if (!device) {
+    const error = new Error(`Unknown Shelly device: ${deviceId}`);
+    error.statusCode = 404;
+    throw error;
+  }
+  return device;
+}
+
+function buildShellyUrl(device, path, query = {}) {
+  const normalizedBase = normalizeBaseUrl(device.host);
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+  const url = new URL(normalizedPath, normalizedBase);
+
+  Object.entries(query).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+    url.searchParams.set(key, String(value));
+  });
+
+  return url;
+}
+
+async function fetchShelly(device, path, { query } = {}) {
+  const url = buildShellyUrl(device, path, query);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), SHELLY_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      const message = await response.text().catch(() => '');
+      throw new Error(
+        `Shelly request failed with status ${response.status} ${response.statusText}: ${message}`.trim()
+      );
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+      return await response.json();
+    }
+
+    const text = await response.text();
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      return { raw: text };
+    }
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
 
 function addToHistory(sample) {
   metricsHistory.push(sample);
@@ -87,8 +202,106 @@ app.get('/api/metrics/history', (req, res) => {
   });
 });
 
-if (!global.__metricsServerStarted) { global.__metricsServerStarted = true;
-app.listen(PORT, () => {
-  console.log(`Metrics server listening on port ${PORT}`);
+function summarizeDevice(device) {
+  try {
+    const { hostname, host } = new URL(device.host);
+    return {
+      id: device.id,
+      name: device.name,
+      address: hostname || host || device.host,
+      baseUrl: device.host
+    };
+  } catch (error) {
+    return {
+      id: device.id,
+      name: device.name,
+      address: device.host,
+      baseUrl: device.host
+    };
+  }
+}
+
+async function respondWithShellyStatus(res, device) {
+  try {
+    const status = await fetchShelly(device, 'status');
+    res.json(status);
+  } catch (error) {
+    const isTimeout = error?.name === 'AbortError';
+    console.error('Error retrieving Shelly status:', error);
+    res.status(isTimeout ? 504 : 502).json({
+      error: isTimeout
+        ? 'Timed out while contacting Shelly device.'
+        : 'Failed to retrieve Shelly device status.'
+    });
+  }
+}
+
+async function updateShellyRelay(req, res, device) {
+  const { turn } = req.body ?? {};
+  const allowedActions = new Set(['on', 'off', 'toggle']);
+
+  if (typeof turn !== 'string' || !allowedActions.has(turn)) {
+    res.status(400).json({
+      error: "Expected 'turn' to be one of: 'on', 'off', or 'toggle'."
+    });
+    return;
+  }
+
+  try {
+    const response = await fetchShelly(device, 'relay/0', { query: { turn } });
+    res.json(response);
+  } catch (error) {
+    const isTimeout = error?.name === 'AbortError';
+    console.error('Error updating Shelly relay state:', error);
+    res.status(isTimeout ? 504 : 502).json({
+      error: isTimeout
+        ? 'Timed out while updating Shelly relay state.'
+        : 'Failed to update Shelly relay state.'
+    });
+  }
+}
+
+app.get('/api/shelly/devices', (req, res) => {
+  res.json({ devices: shellyDevices.map(summarizeDevice) });
 });
+
+app.get('/api/shelly/status', async (req, res) => {
+  await respondWithShellyStatus(res, shellyDevices[0]);
+});
+
+app.post('/api/shelly/relay', async (req, res) => {
+  await updateShellyRelay(req, res, shellyDevices[0]);
+});
+
+app.get('/api/shelly/:deviceId/status', async (req, res) => {
+  try {
+    const device = getShellyDevice(req.params.deviceId);
+    await respondWithShellyStatus(res, device);
+  } catch (error) {
+    if (error.statusCode === 404) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    throw error;
+  }
+});
+
+app.post('/api/shelly/:deviceId/relay', async (req, res) => {
+  try {
+    const device = getShellyDevice(req.params.deviceId);
+    await updateShellyRelay(req, res, device);
+  } catch (error) {
+    if (error.statusCode === 404) {
+      res.status(404).json({ error: error.message });
+      return;
+    }
+    throw error;
+  }
+});
+
+if (!global.__metricsServerStarted) {
+  global.__metricsServerStarted = true;
+  app.listen(PORT, () => {
+    console.log(`Metrics server listening on port ${PORT}`);
+  });
 }


### PR DESCRIPTION
## Summary
- add server-side Shelly device registry with list, status, and relay endpoints per device
- redesign the Shelly control view with a device picker, animated power toggle, and localized details for "Światło Michał Pokój"
- poll the selected device every 2.5 seconds to keep relay, power, and wifi data live

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6f8ee2f24833181e69545f9387810