### PR TITLE
Handle empty metric history in dashboard chart

### DIFF
--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -380,94 +380,64 @@ const renderChart = () => {
     return
   }
 
-  const chartData = {
-    labels,
-    datasets,
-  }
+  const ctx = chartCanvas.value.getContext('2d')
+  if (!ctx) return
 
-  if (!chartInstance.value) {
-    const ctx = chartCanvas.value.getContext('2d')
-    chartInstance.value = new Chart(ctx, {
-      type: 'line',
-      data: chartData,
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        animation: {
-          duration: 0,
-        },
-        interaction: {
-          mode: 'index',
-          intersect: false,
-        },
-        scales: {
-          y: {
-            type: 'linear',
-            beginAtZero: true,
-            title: {
-              display: true,
-              text: 'Value',
-            },
-          },
-          x: {
-            type: 'category',
-            title: {
-              display: true,
-              text: 'Time',
-            },
-          },
-        },
-        plugins: {
-          legend: {
+  const chartConfig = {
+    type: 'line',
+    data: {
+      labels,
+      datasets,
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: {
+        duration: 0,
+      },
+      interaction: {
+        mode: 'index',
+        intersect: false,
+      },
+      scales: {
+        y: {
+          type: 'linear',
+          beginAtZero: true,
+          title: {
             display: true,
-            position: 'bottom',
+            text: 'Value',
           },
-          tooltip: {
-            callbacks: {
-              label: (context) => {
-                const value = context.parsed?.y
-                if (!Number.isFinite(value)) {
-                  return `${context.dataset.label}: --`
-                }
-                return `${context.dataset.label}: ${value.toFixed(1)}`
-              },
+        },
+        x: {
+          type: 'category',
+          title: {
+            display: true,
+            text: 'Time',
+          },
+        },
+      },
+      plugins: {
+        legend: {
+          display: true,
+          position: 'bottom',
+        },
+        tooltip: {
+          callbacks: {
+            label: (context) => {
+              const value = context.parsed?.y
+              if (!Number.isFinite(value)) {
+                return `${context.dataset.label}: --`
+              }
+              return `${context.dataset.label}: ${value.toFixed(1)}`
             },
           },
         },
       },
-    })
-    return
+    },
   }
 
-  const existingLabels = chartInstance.value.data.labels
-  existingLabels.splice(0, existingLabels.length, ...chartData.labels)
-
-  const existingDatasets = chartInstance.value.data.datasets
-
-  chartData.datasets.forEach((dataset, index) => {
-    const existingDataset = existingDatasets[index]
-
-    if (!existingDataset) {
-      existingDatasets.push({ ...dataset, data: [...dataset.data] })
-      return
-    }
-
-    existingDataset.label = dataset.label
-    existingDataset.borderColor = dataset.borderColor
-    existingDataset.backgroundColor = dataset.backgroundColor
-    existingDataset.fill = dataset.fill
-    existingDataset.tension = dataset.tension
-    existingDataset.pointRadius = dataset.pointRadius
-    existingDataset.pointHoverRadius = dataset.pointHoverRadius
-
-    existingDataset.data.splice(0, existingDataset.data.length, ...dataset.data)
-  })
-
-  if (existingDatasets.length > chartData.datasets.length) {
-    existingDatasets.splice(chartData.datasets.length)
-  }
-
-  chartInstance.value.update('none')
+  destroyChartInstance()
+  chartInstance.value = new Chart(ctx, chartConfig)
 }
 
 onMounted(async () => {

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -348,45 +348,41 @@ const buildDataset = (label, key, color) => ({
 const datasetHasFiniteValues = (dataset) =>
   dataset.data.some((value) => Number.isFinite(value))
 
-const clearExistingChartData = () => {
+const destroyChartInstance = () => {
   if (!chartInstance.value) return
 
-  chartInstance.value.data.labels.splice(
-    0,
-    chartInstance.value.data.labels.length
-  )
-
-  chartInstance.value.data.datasets.forEach((dataset) => {
-    dataset.data.splice(0, dataset.data.length)
-  })
-
-  chartInstance.value.update('none')
+  chartInstance.value.destroy()
+  chartInstance.value = null
 }
 
 const renderChart = () => {
   if (!chartCanvas.value) return
 
-  const chartData = {
-    labels: historyMetrics.value.map((entry) => {
-      if (!entry?.timestamp) return '—'
-      const date = new Date(entry.timestamp)
-      return Number.isNaN(date.getTime())
-        ? '—'
-        : date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-    }),
-    datasets: [
-      buildDataset('CPU Usage (%)', 'cpu', '#0ea5e9'),
-      buildDataset('Memory Usage (%)', 'memory', '#22c55e'),
-      buildDataset('Temperature (°C)', 'temperature', '#f97316'),
-    ],
-  }
+  const labels = historyMetrics.value.map((entry) => {
+    if (!entry?.timestamp) return '—'
+    const date = new Date(entry.timestamp)
+    return Number.isNaN(date.getTime())
+      ? '—'
+      : date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  })
+
+  const datasets = [
+    buildDataset('CPU Usage (%)', 'cpu', '#0ea5e9'),
+    buildDataset('Memory Usage (%)', 'memory', '#22c55e'),
+    buildDataset('Temperature (°C)', 'temperature', '#f97316'),
+  ].filter(datasetHasFiniteValues)
 
   const hasHistorySamples = historyMetrics.value.length > 0
-  const hasRenderableData = chartData.datasets.some(datasetHasFiniteValues)
+  const hasRenderableData = datasets.length > 0
 
   if (!hasHistorySamples || !hasRenderableData) {
-    clearExistingChartData()
+    destroyChartInstance()
     return
+  }
+
+  const chartData = {
+    labels,
+    datasets,
   }
 
   if (!chartInstance.value) {
@@ -502,10 +498,7 @@ onBeforeUnmount(() => {
   }
 
   if (stopPollingLoop) stopPollingLoop()
-  if (chartInstance.value) {
-    chartInstance.value.destroy()
-    chartInstance.value = null
-  }
+  destroyChartInstance()
 })
 </script>
 

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -345,6 +345,24 @@ const buildDataset = (label, key, color) => ({
   pointHoverRadius: 5,
 })
 
+const datasetHasFiniteValues = (dataset) =>
+  dataset.data.some((value) => Number.isFinite(value))
+
+const clearExistingChartData = () => {
+  if (!chartInstance.value) return
+
+  chartInstance.value.data.labels.splice(
+    0,
+    chartInstance.value.data.labels.length
+  )
+
+  chartInstance.value.data.datasets.forEach((dataset) => {
+    dataset.data.splice(0, dataset.data.length)
+  })
+
+  chartInstance.value.update('none')
+}
+
 const renderChart = () => {
   if (!chartCanvas.value) return
 
@@ -361,6 +379,14 @@ const renderChart = () => {
       buildDataset('Memory Usage (%)', 'memory', '#22c55e'),
       buildDataset('Temperature (°C)', 'temperature', '#f97316'),
     ],
+  }
+
+  const hasHistorySamples = historyMetrics.value.length > 0
+  const hasRenderableData = chartData.datasets.some(datasetHasFiniteValues)
+
+  if (!hasHistorySamples || !hasRenderableData) {
+    clearExistingChartData()
+    return
   }
 
   if (!chartInstance.value) {
@@ -380,6 +406,7 @@ const renderChart = () => {
         },
         scales: {
           y: {
+            type: 'linear',
             beginAtZero: true,
             title: {
               display: true,
@@ -387,6 +414,7 @@ const renderChart = () => {
             },
           },
           x: {
+            type: 'category',
             title: {
               display: true,
               text: 'Time',


### PR DESCRIPTION
## Summary
- avoid rendering the dashboard chart until history samples with finite values are available
- clear any existing chart data when the history feed is empty and specify explicit scale types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc691842488331b5c5a89107407528