### PR TITLE
Set RoomPi logo as favicon

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/roompi-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Vue</title>
   </head>

--- a/client/public/roompi-logo.svg
+++ b/client/public/roompi-logo.svg
@@ -1,0 +1,41 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="roompiRoof" x1="12" y1="12" x2="84" y2="12" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1e40af" />
+      <stop offset="1" stop-color="#22d3ee" />
+    </linearGradient>
+    <linearGradient id="roompiBody" x1="20" y1="36" x2="76" y2="84" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0f172a" />
+      <stop offset="1" stop-color="#1e293b" />
+    </linearGradient>
+    <filter id="shadow" x="0" y="6" width="96" height="90" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="6" />
+      <feGaussianBlur stdDeviation="6" />
+      <feColorMatrix type="matrix" values="0 0 0 0 0.117647 0 0 0 0 0.141176 0 0 0 0 0.203922 0 0 0 0.18 0" />
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+    </filter>
+  </defs>
+  <g filter="url(#shadow)">
+    <path
+      d="M10 40.65a4 4 0 0 1 1.58-3.19l36-27.3a4 4 0 0 1 4.84 0l36 27.3A4 4 0 0 1 90 40.65V78a8 8 0 0 1-8 8H18a8 8 0 0 1-8-8V40.65Z"
+      fill="url(#roompiBody)"
+      stroke="#1e40af"
+      stroke-width="4"
+      stroke-linejoin="round"
+    />
+    <path
+      d="m14 36 34-25.8a4 4 0 0 1 4.8 0L86 36"
+      stroke="url(#roompiRoof)"
+      stroke-width="10"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </g>
+  <path
+    d="M38 42c0-2.209 1.791-4 4-4h28a4 4 0 1 1 0 8h-8.4c0 9.6-1.79 17.51-5.37 23.36-3.72 6.12-9.16 9.64-16.23 10.55a4 4 0 1 1-1.07-7.93c4.37-.58 7.7-2.97 9.96-7.16 2.12-3.9 3.18-9.18 3.18-15.82H42a4 4 0 0 1-4-4Z"
+    fill="#f8fafc"
+  />
+  <circle cx="32" cy="58" r="6" fill="#22d3ee" />
+  <circle cx="32" cy="58" r="3" fill="#f8fafc" />
+</svg>


### PR DESCRIPTION
## Summary
- update the HTML head to use the RoomPi logo as the site favicon
- add the RoomPi logo asset to the public directory so the tab icon displays correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc7f677e50833194ebabb13de46135