### PR TITLE
Prevent scroll restoration when user scrolls during refresh

### DIFF
--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -157,6 +157,8 @@ const restoreScrollPosition = () => {
   applyScrollPosition(savedPosition)
 }
 
+const SCROLL_RESTORE_TOLERANCE = 2
+
 const withScrollPreserved = async (operation) => {
   if (!isBrowserEnvironment()) {
     return operation()
@@ -169,7 +171,10 @@ const withScrollPreserved = async (operation) => {
   } finally {
     await nextTick()
     window.requestAnimationFrame(() => {
-      applyScrollPosition(previousPosition)
+      const currentPosition = getCurrentScrollPosition()
+      if (Math.abs(currentPosition - previousPosition) <= SCROLL_RESTORE_TOLERANCE) {
+        applyScrollPosition(previousPosition)
+      }
     })
   }
 }


### PR DESCRIPTION
## Summary
- skip restoring the saved dashboard scroll position if the user has moved to a different offset
- add a small tolerance when comparing scroll offsets to allow genuine layout-shift corrections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd275271208331bd4fe80cb787a021