### PR TITLE
Validate metrics sampling configuration

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -25,8 +25,8 @@ node index.js
 The server listens on port `3001` by default. Override the port or sampling behaviour with environment variables:
 
 - `PORT` – HTTP port to listen on (default: `3001`)
-- `SAMPLE_INTERVAL_MS` – Interval between metric samples stored in history (default: `5000` ms)
-- `MAX_METRIC_SAMPLES` – Maximum number of samples kept in the ring buffer (default: `1000`)
+- `SAMPLE_INTERVAL_MS` – Interval between metric samples stored in history (default: `5000` ms, values ≤ 0 fall back to the default)
+- `MAX_METRIC_SAMPLES` – Maximum number of samples kept in the ring buffer (default: `1000`, values < 1 fall back to the default)
 
 ### API Endpoints
 

--- a/server/config.js
+++ b/server/config.js
@@ -4,7 +4,21 @@ import { fileURLToPath } from 'node:url';
 const filePath = fileURLToPath(import.meta.url);
 const directoryPath = path.dirname(filePath);
 
+function getNumericConfig(envValue, defaultValue, minThreshold = -Infinity) {
+  if (envValue == null || envValue === '') {
+    return defaultValue;
+  }
+
+  const parsedValue = Number.parseInt(String(envValue).trim(), 10);
+
+  if (!Number.isFinite(parsedValue) || Number.isNaN(parsedValue) || parsedValue < minThreshold) {
+    return defaultValue;
+  }
+
+  return parsedValue;
+}
+
 export const PORT = Number(process.env.PORT) || 3000;
-export const SAMPLE_INTERVAL_MS = Number.parseInt(process.env.SAMPLE_INTERVAL_MS ?? '1000', 10);
-export const MAX_SAMPLES = Number.parseInt(process.env.MAX_METRIC_SAMPLES ?? '1000', 10);
+export const SAMPLE_INTERVAL_MS = getNumericConfig(process.env.SAMPLE_INTERVAL_MS, 1000, 1);
+export const MAX_SAMPLES = getNumericConfig(process.env.MAX_METRIC_SAMPLES, 1000, 1);
 export const DEVICES_FILE_PATH = path.join(directoryPath, 'devices.json');


### PR DESCRIPTION
## Summary
- add a helper to normalise numeric environment variables used for metrics sampling
- ensure the sampling interval and buffer size fall back to safe defaults when out of range
- document the expected ranges for the sampling-related environment variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd32fefd9c83319e799d194be5039a