### PR TITLE
Validate PORT configuration bounds

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -24,7 +24,7 @@ node index.js
 
 The server listens on port `3000` by default. Override the port or sampling behaviour with environment variables:
 
-- `PORT` – HTTP port to listen on (default: `3000`)
+- `PORT` – HTTP port to listen on (default: `3000`; accepts `0` for an ephemeral port, values outside `0-65535` fall back to the default)
 - `SAMPLE_INTERVAL_MS` – Interval between metric samples stored in history (default: `1000` ms)
 - `MAX_METRIC_SAMPLES` – Maximum number of samples kept in the ring buffer (default: `1000`)
 

--- a/server/config.js
+++ b/server/config.js
@@ -4,21 +4,31 @@ import { fileURLToPath } from 'node:url';
 const filePath = fileURLToPath(import.meta.url);
 const directoryPath = path.dirname(filePath);
 
-function getNumericConfig(envValue, defaultValue, minThreshold = -Infinity) {
+function getNumericConfig(
+  envValue,
+  defaultValue,
+  minThreshold = -Infinity,
+  maxThreshold = Infinity,
+) {
   if (envValue == null || envValue === '') {
     return defaultValue;
   }
 
   const parsedValue = Number.parseInt(String(envValue).trim(), 10);
 
-  if (!Number.isFinite(parsedValue) || Number.isNaN(parsedValue) || parsedValue < minThreshold) {
+  if (
+    !Number.isFinite(parsedValue) ||
+    Number.isNaN(parsedValue) ||
+    parsedValue < minThreshold ||
+    parsedValue > maxThreshold
+  ) {
     return defaultValue;
   }
 
   return parsedValue;
 }
 
-export const PORT = Number(process.env.PORT) || 3000;
+export const PORT = getNumericConfig(process.env.PORT, 3000, 0, 65535);
 export const SAMPLE_INTERVAL_MS = getNumericConfig(process.env.SAMPLE_INTERVAL_MS, 1000, 1);
 export const MAX_SAMPLES = getNumericConfig(process.env.MAX_METRIC_SAMPLES, 1000, 1);
 export const DEVICES_FILE_PATH = path.join(directoryPath, 'devices.json');


### PR DESCRIPTION
## Summary
- extend the numeric config helper to support both minimum and maximum constraints
- parse PORT with the helper to ensure values stay within the TCP range while still allowing 0
- document the updated PORT behaviour in the server README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd39278ebc8331ac1a2ac941f8a29d