### PR TITLE
Format complex sensor readings

### DIFF
--- a/client/src/utils/sensorFormatting.js
+++ b/client/src/utils/sensorFormatting.js
@@ -1,0 +1,110 @@
+const KNOWN_SUFFIX_UNITS = new Map([
+  ['Percent', '%'],
+  ['C', '°C'],
+  ['F', '°F'],
+  ['K', 'K']
+])
+
+const isPlainObject = (value) => {
+  if (Object.prototype.toString.call(value) !== '[object Object]') {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === null || prototype === Object.prototype
+}
+
+const humanize = (input) => {
+  if (!input) {
+    return ''
+  }
+
+  const spaced = input
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!spaced) {
+    return ''
+  }
+
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+const normalizeKey = (key) => {
+  for (const [suffix, unit] of KNOWN_SUFFIX_UNITS) {
+    if (key.endsWith(suffix) && key.length > suffix.length) {
+      const baseKey = key.slice(0, key.length - suffix.length)
+      return {
+        label: humanize(baseKey),
+        unit
+      }
+    }
+  }
+
+  return {
+    label: humanize(key),
+    unit: ''
+  }
+}
+
+const formatValueWithUnit = (value, unit) => {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  const stringValue =
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+      ? String(value)
+      : null
+
+  if (stringValue === null) {
+    return null
+  }
+
+  return unit ? `${stringValue} ${unit}` : stringValue
+}
+
+export const formatSensorReading = (state) => {
+  if (!state || typeof state !== 'object') {
+    return 'Unavailable'
+  }
+
+  if (Object.prototype.hasOwnProperty.call(state, 'value')) {
+    const { value, unit } = state
+
+    if (value === null || value === undefined) {
+      return 'Unavailable'
+    }
+
+    return `${value}${unit ? ` ${unit}` : ''}`
+  }
+
+  if (!isPlainObject(state)) {
+    return 'Unavailable'
+  }
+
+  const formattedEntries = Object.entries(state)
+    .map(([key, value]) => {
+      const { label, unit } = normalizeKey(key)
+      const formattedValue = formatValueWithUnit(value, unit)
+
+      if (!label || formattedValue === null) {
+        return null
+      }
+
+      return `${label}: ${formattedValue}`
+    })
+    .filter((entry) => entry !== null)
+
+  if (!formattedEntries.length) {
+    return 'Unavailable'
+  }
+
+  return formattedEntries.join(', ')
+}
+
+export default formatSensorReading

--- a/client/src/utils/sensorFormatting.js
+++ b/client/src/utils/sensorFormatting.js
@@ -104,7 +104,7 @@ export const formatSensorReading = (state) => {
     return 'Unavailable'
   }
 
-  return formattedEntries.join(', ')
+  return formattedEntries.join('\n')
 }
 
 export default formatSensorReading

--- a/client/src/views/Devices.vue
+++ b/client/src/views/Devices.vue
@@ -61,8 +61,9 @@
           </template>
 
           <template v-else-if="device.type === 'sensor'">
-            <p class="device-state">
-              Reading: {{ formatSensorReading(device.state) }}
+            <p class="device-state device-state--sensor">
+              <span class="device-state__label">Reading:</span>
+              <span class="device-state__value">{{ formatSensorReading(device.state) }}</span>
             </p>
             <p class="device-hint">Sensors are read-only.</p>
           </template>
@@ -304,6 +305,21 @@ onUnmounted(() => {
   color: #0f172a;
 }
 
+.device-state--sensor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.device-state__label {
+  font-weight: inherit;
+}
+
+.device-state__value {
+  white-space: pre-line;
+  font-weight: 400;
+}
+
 .device-hint {
   font-size: 0.875rem;
   color: #475569;
@@ -414,6 +430,10 @@ onUnmounted(() => {
   .device-state,
   .slider-label {
     color: #e2e8f0;
+  }
+
+  .device-state__value {
+    color: inherit;
   }
 
   .device-type {

--- a/client/src/views/Devices.vue
+++ b/client/src/views/Devices.vue
@@ -83,6 +83,7 @@
 <script setup>
 import { onMounted, onUnmounted, ref } from 'vue'
 import axios from 'axios'
+import { formatSensorReading as formatSensorReadingImpl } from '../utils/sensorFormatting.js'
 
 const devices = ref([])
 const isRefreshing = ref(false)
@@ -169,17 +170,7 @@ const updateDimmer = async (device, level) => {
   await performDeviceAction(device, { level })
 }
 
-const formatSensorReading = (state) => {
-  if (!state || typeof state !== 'object') {
-    return 'Unavailable'
-  }
-
-  if (state.value === undefined) {
-    return JSON.stringify(state)
-  }
-
-  return `${state.value}${state.unit ? ` ${state.unit}` : ''}`
-}
+const formatSensorReading = (state) => formatSensorReadingImpl(state)
 
 const stopAutoRefresh = () => {
   if (autoRefreshTimerId !== null && typeof window !== 'undefined') {

--- a/client/tests/sensorFormatting.test.js
+++ b/client/tests/sensorFormatting.test.js
@@ -21,7 +21,7 @@ test('formats multi-field sensor objects with known suffixes', () => {
     humidityPercent: 40
   })
 
-  assert.equal(reading, 'Temperature: 24.2 °C, Humidity: 40 %')
+  assert.equal(reading, 'Temperature: 24.2 °C\nHumidity: 40 %')
 })
 
 test('ignores keys with empty values and falls back when nothing remains', () => {

--- a/client/tests/sensorFormatting.test.js
+++ b/client/tests/sensorFormatting.test.js
@@ -1,0 +1,41 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { formatSensorReading } from '../src/utils/sensorFormatting.js'
+
+test('returns Unavailable for null or non-object states', () => {
+  assert.equal(formatSensorReading(null), 'Unavailable')
+  assert.equal(formatSensorReading(undefined), 'Unavailable')
+  assert.equal(formatSensorReading('offline'), 'Unavailable')
+})
+
+test('preserves value/unit sensor shape', () => {
+  assert.equal(formatSensorReading({ value: 12 }), '12')
+  assert.equal(formatSensorReading({ value: 12, unit: 'Lux' }), '12 Lux')
+  assert.equal(formatSensorReading({ value: null, unit: 'Lux' }), 'Unavailable')
+})
+
+test('formats multi-field sensor objects with known suffixes', () => {
+  const reading = formatSensorReading({
+    temperatureC: 24.2,
+    humidityPercent: 40
+  })
+
+  assert.equal(reading, 'Temperature: 24.2 °C, Humidity: 40 %')
+})
+
+test('ignores keys with empty values and falls back when nothing remains', () => {
+  assert.equal(
+    formatSensorReading({ temperatureC: null, humidityPercent: undefined }),
+    'Unavailable'
+  )
+})
+
+test('returns Unavailable for non-plain objects', () => {
+  const date = new Date()
+  assert.equal(formatSensorReading(date), 'Unavailable')
+})
+
+test('humanises unknown suffix keys without appending units', () => {
+  assert.equal(formatSensorReading({ dew_point: 13 }), 'Dew point: 13')
+})


### PR DESCRIPTION
## Summary
- enhance the Devices view to consume a shared sensor reading formatter
- add a formatter utility that humanises multi-field sensor states and applies known units
- cover the helper with node-based tests, including the rack temperature sensor scenario

## Testing
- node --test client/tests/sensorFormatting.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd3c26eef88331830c3caa2c109bef