### PR TITLE
Add disk usage metric to dashboard visualizations

### DIFF
--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -22,7 +22,7 @@
       <div class="chart-wrapper">
         <canvas
           ref="chartCanvas"
-          aria-label="Line chart showing CPU, Memory, and Temperature history"
+          aria-label="Line chart showing CPU, Memory, Disk, and Temperature history"
           role="img"
         ></canvas>
       </div>
@@ -66,6 +66,7 @@ const errorMessage = ref('')
 const currentMetrics = ref({
   cpu: null,
   memory: null,
+  disk: null,
   temperature: null,
   timestamp: null,
 })
@@ -190,17 +191,34 @@ const lastUpdated = computed(() => {
 const metricCards = computed(() => [
   {
     label: 'CPU Usage',
-    value: currentMetrics.value.cpu !== null ? `${currentMetrics.value.cpu.toFixed(1)}%` : null,
+    value:
+      currentMetrics.value.cpu !== null
+        ? `${currentMetrics.value.cpu.toFixed(1)}%`
+        : null,
     description: 'Current CPU utilization',
   },
   {
     label: 'Memory Usage',
-    value: currentMetrics.value.memory !== null ? `${currentMetrics.value.memory.toFixed(1)}%` : null,
+    value:
+      currentMetrics.value.memory !== null
+        ? `${currentMetrics.value.memory.toFixed(1)}%`
+        : null,
     description: 'Current memory consumption',
   },
   {
+    label: 'Disk Usage',
+    value:
+      currentMetrics.value.disk !== null
+        ? `${currentMetrics.value.disk.toFixed(1)}%`
+        : null,
+    description: 'Current disk utilization',
+  },
+  {
     label: 'Temperature',
-    value: currentMetrics.value.temperature !== null ? `${currentMetrics.value.temperature.toFixed(1)}°C` : null,
+    value:
+      currentMetrics.value.temperature !== null
+        ? `${currentMetrics.value.temperature.toFixed(1)}°C`
+        : null,
     description: 'Current system temperature',
   },
 ])
@@ -248,6 +266,7 @@ const mapCurrentMetrics = (data) => {
     return {
       cpu: null,
       memory: null,
+      disk: null,
       temperature: null,
       timestamp: null,
     }
@@ -261,12 +280,20 @@ const mapCurrentMetrics = (data) => {
       ? (memoryUsed / memoryTotal) * 100
       : null
 
+  const diskUsed = toFiniteNumber(data?.disk?.used)
+  const diskTotal = toFiniteNumber(data?.disk?.total)
+  const diskPercent =
+    diskUsed !== null && diskTotal !== null && diskTotal !== 0
+      ? (diskUsed / diskTotal) * 100
+      : null
+
   const temperatureMain = toFiniteNumber(data?.temperature?.main)
   const temperatureMax = toFiniteNumber(data?.temperature?.max)
 
   return {
     cpu: cpuLoad,
     memory: memoryPercent,
+    disk: diskPercent,
     temperature: temperatureMain ?? temperatureMax,
     timestamp: data?.timestamp ?? null,
   }
@@ -278,6 +305,7 @@ const mapHistorySample = (sample) => {
       timestamp: null,
       cpu: null,
       memory: null,
+      disk: null,
       temperature: null,
     }
   }
@@ -290,6 +318,13 @@ const mapHistorySample = (sample) => {
       ? (memoryUsed / memoryTotal) * 100
       : null
 
+  const diskUsed = toFiniteNumber(sample?.disk?.used)
+  const diskTotal = toFiniteNumber(sample?.disk?.total)
+  const diskPercent =
+    diskUsed !== null && diskTotal !== null && diskTotal !== 0
+      ? (diskUsed / diskTotal) * 100
+      : null
+
   const temperatureMain = toFiniteNumber(sample?.temperature?.main)
   const temperatureMax = toFiniteNumber(sample?.temperature?.max)
 
@@ -297,6 +332,7 @@ const mapHistorySample = (sample) => {
     timestamp: sample?.timestamp ?? null,
     cpu: cpuLoad,
     memory: memoryPercent,
+    disk: diskPercent,
     temperature: temperatureMain ?? temperatureMax,
   }
 }
@@ -374,6 +410,7 @@ const renderChart = () => {
   const datasets = [
     buildDataset('CPU Usage (%)', 'cpu', '#0ea5e9'),
     buildDataset('Memory Usage (%)', 'memory', '#22c55e'),
+    buildDataset('Disk Usage (%)', 'disk', '#a855f7'),
     buildDataset('Temperature (°C)', 'temperature', '#f97316'),
   ].filter(datasetHasFiniteValues)
 


### PR DESCRIPTION
## Summary
- compute disk usage percentages alongside cpu, memory, and temperature metrics for current and historical samples
- display disk usage on the dashboard card grid and include it in the historical chart with updated accessibility text

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68de685e511883318ce37290a58700d2