### PR TITLE
Allow device controls during refresh

### DIFF
--- a/client/src/views/Devices.vue
+++ b/client/src/views/Devices.vue
@@ -33,7 +33,7 @@
               ]"
               type="button"
               @click="toggleSwitch(device)"
-              :disabled="isRefreshing || isDevicePending(device.id)"
+              :disabled="isDevicePending(device.id)"
               :aria-pressed="device.state?.on ?? false"
               :aria-busy="isDevicePending(device.id)"
             >
@@ -54,7 +54,7 @@
               step="1"
               :id="`dimmer-${device.id}`"
               :value="device.state?.level ?? 0"
-              :disabled="isRefreshing || isDevicePending(device.id)"
+              :disabled="isDevicePending(device.id)"
               :aria-busy="isDevicePending(device.id)"
               @change="(event) => updateDimmer(device, Number.parseInt(event.target.value, 10))"
             />


### PR DESCRIPTION
## Summary
- keep device controls enabled during device list refreshes so only the refresh button updates state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5501bbc988331a492a0e89887ac23