### PR TITLE
Capture rack sensor refresh timestamps

### DIFF
--- a/client/src/utils/sensorFormatting.js
+++ b/client/src/utils/sensorFormatting.js
@@ -32,6 +32,15 @@ const humanize = (input) => {
   return spaced.charAt(0).toUpperCase() + spaced.slice(1)
 }
 
+const IGNORED_KEYS = new Set([
+  'pin',
+  'temperatureAvgC',
+  'humidityAvgPercent',
+  'avgWindow',
+  'avgSamples',
+  'lastObservedAtIso',
+])
+
 const normalizeKey = (key) => {
   for (const [suffix, unit] of KNOWN_SUFFIX_UNITS) {
     if (key.endsWith(suffix) && key.length > suffix.length) {
@@ -88,6 +97,7 @@ export const formatSensorReading = (state) => {
   }
 
   const formattedEntries = Object.entries(state)
+    .filter(([key]) => !IGNORED_KEYS.has(key))
     .map(([key, value]) => {
       const { label, unit } = normalizeKey(key)
       const formattedValue = formatValueWithUnit(value, unit)

--- a/client/tests/sensorFormatting.test.js
+++ b/client/tests/sensorFormatting.test.js
@@ -18,10 +18,26 @@ test('preserves value/unit sensor shape', () => {
 test('formats multi-field sensor objects with known suffixes', () => {
   const reading = formatSensorReading({
     temperatureC: 24.2,
-    humidityPercent: 40
+    humidityPercent: 40,
+    temperatureAvgC: 24.0,
+    humidityAvgPercent: 39.5,
+    avgWindow: 8,
+    avgSamples: 4,
+    uptimeMs: 1500,
+    stale: false,
+    pin: 'D1(GPIO5)',
+    lastObservedAtIso: '2024-01-20T12:00:00.000Z'
   })
 
-  assert.equal(reading, 'Temperature: 24.2 °C\nHumidity: 40 %')
+  assert.equal(
+    reading,
+    [
+      'Temperature: 24.2 °C',
+      'Humidity: 40 %',
+      'Uptime Ms: 1500',
+      'Stale: false'
+    ].join('\n')
+  )
 })
 
 test('ignores keys with empty values and falls back when nothing remains', () => {

--- a/server/README.md
+++ b/server/README.md
@@ -49,7 +49,7 @@ The server listens on port `3000` by default. Override the port or sampling beha
 - Sample entries ship with the repository so the manual tests below can run end-to-end:
   - `shelly1plus-relay` – A Shelly Plus 1 relay exposed as a `switch`. Its state synchronises with the physical device using the `integration` block (`type: "shelly-gen3"`, `ip`, and `switchId`).
   - `bedroom-dimmer` – A virtual `dimmer` whose `state.level` defaults to `42`. Posting a new level updates both the in-memory state and `devices.json`.
-  - `rack-temperature-sensor` – A read-only `sensor` that publishes `state.temperatureC` and `state.humidityPercent`.
+  - `rack-temperature-sensor` – A read-only `sensor` that publishes `state.temperatureC`, `state.humidityPercent`, and moving average metadata (`state.temperatureAvgC`, `state.humidityAvgPercent`, `state.avgWindow`, `state.avgSamples`, plus uptime/staleness details).
 - **Manual test plan:**
   1. Start the server (`node index.js`) and verify that `GET /api/devices` returns the contents of `devices.json`.
   2. Send `POST /api/devices/shelly1plus-relay/actions` with `{ "action": "toggle" }` and ensure the response flips `state.on` and that `devices.json` updates accordingly (the server will also call the Shelly REST API using the metadata from the sample entry).

--- a/server/devices.json
+++ b/server/devices.json
@@ -26,7 +26,16 @@
     "type": "sensor",
     "state": {
       "temperatureC": 24.2,
-      "humidityPercent": 40
+      "humidityPercent": 40,
+      "temperatureAvgC": 24.0,
+      "humidityAvgPercent": 39.5,
+      "avgWindow": 8,
+      "avgSamples": 4,
+      "uptimeMs": 12345,
+      "stale": false,
+      "sensor": "DHT11",
+      "pin": "D1(GPIO5)",
+      "lastObservedAtIso": "2024-01-20T12:00:00.000Z"
     }
   }
 ]

--- a/server/routes/deviceRoutes.js
+++ b/server/routes/deviceRoutes.js
@@ -63,6 +63,22 @@ async function refreshRackTemperatureSensor() {
     statePatch.humidityPercent = payload.humidity_pct;
   }
 
+  if (Number.isFinite(payload.temperature_avg_c)) {
+    statePatch.temperatureAvgC = payload.temperature_avg_c;
+  }
+
+  if (Number.isFinite(payload.humidity_avg_pct)) {
+    statePatch.humidityAvgPercent = payload.humidity_avg_pct;
+  }
+
+  if (Number.isFinite(payload.avg_window)) {
+    statePatch.avgWindow = payload.avg_window;
+  }
+
+  if (Number.isFinite(payload.avg_samples)) {
+    statePatch.avgSamples = payload.avg_samples;
+  }
+
   if (Number.isFinite(payload.uptime_ms)) {
     statePatch.uptimeMs = payload.uptime_ms;
   }
@@ -78,6 +94,12 @@ async function refreshRackTemperatureSensor() {
   if (typeof payload.pin === 'string' && payload.pin.trim()) {
     statePatch.pin = payload.pin.trim();
   }
+
+  // Record when we last received a response from the rack sensor so the
+  // dashboard can react to refreshes even if the primary readings remain
+  // unchanged (for example when the sensor wakes from deep sleep and reports
+  // identical values).
+  statePatch.lastObservedAtIso = new Date().toISOString();
 
   const nextState = { ...existingState, ...statePatch };
   const comparisonKeys = new Set([


### PR DESCRIPTION
## Summary
- stamp rack sensor updates with an ISO timestamp so refreshes are recorded even when readings stay the same
- hide the new bookkeeping field from the dashboard formatter and tests to keep the UI unchanged
- seed the sample device state with the new timestamp metadata for consistency

## Testing
- node --test tests/sensorFormatting.test.js (client)


------
https://chatgpt.com/codex/tasks/task_e_68e5544c0abc8331a8a67f8b60349188