### PR TITLE
Refactor device routes into dedicated service layer

### DIFF
--- a/server/routes/deviceRoutes.js
+++ b/server/routes/deviceRoutes.js
@@ -1,161 +1,17 @@
 import { Router } from 'express';
 
-import { findDeviceById, listDevices, updateDeviceState } from '../deviceStore.js';
+import { findDeviceById, listDevices } from '../deviceStore.js';
 import {
-  applyShellySwitchState,
-  extractShellySwitchState,
-  fetchShellySwitchState,
-} from '../shellyIntegration.js';
-import { RACK_TEMPERATURE_SENSOR_URL } from '../config.js';
+  DeviceActionValidationError,
+  performDeviceAction,
+  refreshAllDeviceStates,
+} from '../services/deviceStateService.js';
 
 const router = Router();
 
-const RACK_TEMPERATURE_SENSOR_ID = 'rack-temperature-sensor';
-
-async function refreshRackTemperatureSensor() {
-  const device = findDeviceById(RACK_TEMPERATURE_SENSOR_ID);
-  if (!device) {
-    return;
-  }
-
-  let response;
-  try {
-    response = await fetch(RACK_TEMPERATURE_SENSOR_URL, {
-      headers: { Accept: 'application/json' },
-    });
-  } catch (error) {
-    console.warn(
-      `Failed to connect to rack temperature sensor at ${RACK_TEMPERATURE_SENSOR_URL}:`,
-      error,
-    );
-    return;
-  }
-
-  if (!response.ok) {
-    const responseText = await response.text().catch(() => '');
-    console.warn(
-      `Rack temperature sensor at ${RACK_TEMPERATURE_SENSOR_URL} responded with ${response.status} ${response.statusText}: ${responseText}`,
-    );
-    return;
-  }
-
-  let payload;
-  try {
-    payload = await response.json();
-  } catch (error) {
-    console.warn('Rack temperature sensor returned invalid JSON payload:', error);
-    return;
-  }
-
-  if (!payload || typeof payload !== 'object') {
-    console.warn('Rack temperature sensor returned an unexpected payload:', payload);
-    return;
-  }
-
-  const existingState = device.state ?? {};
-  const statePatch = {};
-
-  if (Number.isFinite(payload.temperature_c)) {
-    statePatch.temperatureC = payload.temperature_c;
-  }
-
-  if (Number.isFinite(payload.humidity_pct)) {
-    statePatch.humidityPercent = payload.humidity_pct;
-  }
-
-  if (Number.isFinite(payload.temperature_avg_c)) {
-    statePatch.temperatureAvgC = payload.temperature_avg_c;
-  }
-
-  if (Number.isFinite(payload.humidity_avg_pct)) {
-    statePatch.humidityAvgPercent = payload.humidity_avg_pct;
-  }
-
-  if (Number.isFinite(payload.avg_window)) {
-    statePatch.avgWindow = payload.avg_window;
-  }
-
-  if (Number.isFinite(payload.avg_samples)) {
-    statePatch.avgSamples = payload.avg_samples;
-  }
-
-  if (Number.isFinite(payload.uptime_ms)) {
-    statePatch.uptimeMs = payload.uptime_ms;
-  }
-
-  if (typeof payload.stale === 'boolean') {
-    statePatch.stale = payload.stale;
-  }
-
-  if (typeof payload.sensor === 'string' && payload.sensor.trim()) {
-    statePatch.sensor = payload.sensor.trim();
-  }
-
-  if (typeof payload.pin === 'string' && payload.pin.trim()) {
-    statePatch.pin = payload.pin.trim();
-  }
-
-  const nextState = { ...existingState, ...statePatch };
-  const comparisonKeys = new Set([
-    ...Object.keys(existingState),
-    ...Object.keys(nextState),
-  ]);
-
-  const hasChanges = Array.from(comparisonKeys).some(
-    (key) => !Object.is(existingState[key], nextState[key]),
-  );
-
-  if (!hasChanges) {
-    return;
-  }
-
-  try {
-    await updateDeviceState(device.id, () => nextState);
-  } catch (error) {
-    console.warn('Failed to persist rack temperature sensor state:', error);
-  }
-}
-
-async function refreshShellySwitchStates() {
-  const devices = listDevices();
-
-  const shellySwitches = devices.filter(
-    (device) => device.type === 'switch' && device.integration?.type === 'shelly-gen3',
-  );
-
-  await Promise.all(
-    shellySwitches.map(async (device) => {
-      try {
-        const status = await fetchShellySwitchState(device);
-        const parsedState = extractShellySwitchState(status);
-
-        if (!parsedState || typeof parsedState.on !== 'boolean') {
-          return;
-        }
-
-        const currentState = findDeviceById(device.id)?.state ?? {};
-        const hasChanges = Object.entries(parsedState).some(
-          ([key, value]) => currentState?.[key] !== value,
-        );
-
-        if (!hasChanges) {
-          return;
-        }
-
-        await updateDeviceState(device.id, (state) => ({
-          ...state,
-          ...parsedState,
-        }));
-      } catch (error) {
-        console.warn(`Failed to refresh state from Shelly device ${device.id}:`, error);
-      }
-    }),
-  );
-}
-
 router.get('/', async (req, res) => {
   try {
-    await Promise.all([refreshShellySwitchStates(), refreshRackTemperatureSensor()]);
+    await refreshAllDeviceStates();
   } catch (error) {
     console.warn('Unexpected error while refreshing device states:', error);
   }
@@ -172,102 +28,13 @@ router.post('/:id/actions', async (req, res) => {
   }
 
   try {
-    let updatedDevice = device;
-
-    switch (device.type) {
-      case 'switch': {
-        const { action, on } = req.body ?? {};
-        let desiredOn;
-        let currentOn = device.state?.on ?? false;
-
-        if (device.integration?.type === 'shelly-gen3' && action === 'toggle') {
-          try {
-            const shellyStatus = await fetchShellySwitchState(device);
-            const parsedState = extractShellySwitchState(shellyStatus);
-
-            if (parsedState && typeof parsedState.on === 'boolean') {
-              currentOn = parsedState.on;
-            }
-          } catch (statusError) {
-            console.warn(
-              `Failed to read current state from Shelly device ${deviceId}:`,
-              statusError,
-            );
-          }
-        }
-
-        if (action === 'toggle') {
-          desiredOn = !currentOn;
-        } else if (typeof on === 'boolean') {
-          desiredOn = on;
-        } else {
-          return res.status(400).json({
-            error: 'Switch actions require { action: "toggle" } or { on: boolean }',
-          });
-        }
-
-        if (device.integration?.type === 'shelly-gen3') {
-          const shellyResult = await applyShellySwitchState(device, desiredOn);
-          const immediateState = extractShellySwitchState(shellyResult);
-          let latestState = immediateState ?? null;
-
-          try {
-            const shellyStatus = await fetchShellySwitchState(device);
-            const refreshedState = extractShellySwitchState(shellyStatus);
-            if (refreshedState) {
-              latestState = { ...(latestState ?? {}), ...refreshedState };
-            }
-          } catch (statusError) {
-            console.warn(
-              `Failed to refresh state from Shelly device ${deviceId} after update:`,
-              statusError,
-            );
-          }
-
-          const statePatch = { ...(latestState ?? {}) };
-          if (typeof statePatch.on !== 'boolean') {
-            statePatch.on = desiredOn;
-          }
-
-          updatedDevice = await updateDeviceState(deviceId, (state) => ({
-            ...state,
-            ...statePatch,
-          }));
-        } else {
-          updatedDevice = await updateDeviceState(deviceId, (state) => ({
-            ...state,
-            on: desiredOn,
-          }));
-        }
-        break;
-      }
-      case 'dimmer': {
-        const { level } = req.body ?? {};
-        const parsedLevel = Number.parseInt(level, 10);
-        if (!Number.isFinite(parsedLevel) || parsedLevel < 0 || parsedLevel > 100) {
-          return res.status(400).json({
-            error: 'Dimmer actions require a level between 0 and 100',
-          });
-        }
-
-        updatedDevice = await updateDeviceState(deviceId, (state) => ({
-          ...state,
-          level: parsedLevel,
-        }));
-        break;
-      }
-      case 'sensor': {
-        return res.status(400).json({ error: 'Sensor devices are read-only' });
-      }
-      default: {
-        return res.status(400).json({
-          error: `Device type "${device.type}" does not support actions`,
-        });
-      }
-    }
-
+    const updatedDevice = await performDeviceAction(device, req.body ?? {});
     res.json(updatedDevice);
   } catch (error) {
+    if (error instanceof DeviceActionValidationError) {
+      return res.status(error.statusCode).json({ error: error.message });
+    }
+
     console.error(`Failed to update device ${deviceId}:`, error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     res.status(500).json({ error: `Failed to update device state: ${errorMessage}` });

--- a/server/services/deviceStateService.js
+++ b/server/services/deviceStateService.js
@@ -1,0 +1,268 @@
+import { findDeviceById, listDevices, updateDeviceState } from '../deviceStore.js';
+import {
+  applyShellySwitchState,
+  extractShellySwitchState,
+  fetchShellySwitchState,
+} from '../shellyIntegration.js';
+import { RACK_TEMPERATURE_SENSOR_URL } from '../config.js';
+
+const RACK_TEMPERATURE_SENSOR_ID = 'rack-temperature-sensor';
+
+function normalizeRackSensorPayload(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const statePatch = {};
+
+  if (Number.isFinite(payload.temperature_c)) {
+    statePatch.temperatureC = payload.temperature_c;
+  }
+  if (Number.isFinite(payload.humidity_pct)) {
+    statePatch.humidityPercent = payload.humidity_pct;
+  }
+  if (Number.isFinite(payload.temperature_avg_c)) {
+    statePatch.temperatureAvgC = payload.temperature_avg_c;
+  }
+  if (Number.isFinite(payload.humidity_avg_pct)) {
+    statePatch.humidityAvgPercent = payload.humidity_avg_pct;
+  }
+  if (Number.isFinite(payload.avg_window)) {
+    statePatch.avgWindow = payload.avg_window;
+  }
+  if (Number.isFinite(payload.avg_samples)) {
+    statePatch.avgSamples = payload.avg_samples;
+  }
+  if (Number.isFinite(payload.uptime_ms)) {
+    statePatch.uptimeMs = payload.uptime_ms;
+  }
+  if (typeof payload.stale === 'boolean') {
+    statePatch.stale = payload.stale;
+  }
+  if (typeof payload.sensor === 'string' && payload.sensor.trim()) {
+    statePatch.sensor = payload.sensor.trim();
+  }
+  if (typeof payload.pin === 'string' && payload.pin.trim()) {
+    statePatch.pin = payload.pin.trim();
+  }
+
+  return Object.keys(statePatch).length > 0 ? statePatch : null;
+}
+
+async function fetchRackSensorPayload() {
+  let response;
+
+  try {
+    response = await fetch(RACK_TEMPERATURE_SENSOR_URL, {
+      headers: { Accept: 'application/json' },
+    });
+  } catch (error) {
+    console.warn(
+      `Failed to connect to rack temperature sensor at ${RACK_TEMPERATURE_SENSOR_URL}:`,
+      error,
+    );
+    return null;
+  }
+
+  if (!response.ok) {
+    const responseText = await response.text().catch(() => '');
+    console.warn(
+      `Rack temperature sensor at ${RACK_TEMPERATURE_SENSOR_URL} responded with ${response.status} ${response.statusText}: ${responseText}`,
+    );
+    return null;
+  }
+
+  try {
+    return await response.json();
+  } catch (error) {
+    console.warn('Rack temperature sensor returned invalid JSON payload:', error);
+    return null;
+  }
+}
+
+export async function refreshRackTemperatureSensor() {
+  const device = findDeviceById(RACK_TEMPERATURE_SENSOR_ID);
+  if (!device) {
+    return;
+  }
+
+  const payload = await fetchRackSensorPayload();
+  if (!payload) {
+    return;
+  }
+
+  const statePatch = normalizeRackSensorPayload(payload);
+  if (!statePatch) {
+    console.warn('Rack temperature sensor returned an unexpected payload:', payload);
+    return;
+  }
+
+  const existingState = device.state ?? {};
+  const nextState = { ...existingState, ...statePatch };
+
+  const hasChanges = Array.from(
+    new Set([...Object.keys(existingState), ...Object.keys(nextState)]),
+  ).some((key) => !Object.is(existingState[key], nextState[key]));
+
+  if (!hasChanges) {
+    return;
+  }
+
+  try {
+    await updateDeviceState(device.id, () => nextState);
+  } catch (error) {
+    console.warn('Failed to persist rack temperature sensor state:', error);
+  }
+}
+
+export async function refreshShellySwitchStates() {
+  const devices = listDevices();
+  const shellySwitches = devices.filter(
+    (device) => device.type === 'switch' && device.integration?.type === 'shelly-gen3',
+  );
+
+  await Promise.all(
+    shellySwitches.map(async (device) => {
+      try {
+        const status = await fetchShellySwitchState(device);
+        const parsedState = extractShellySwitchState(status);
+
+        if (!parsedState || typeof parsedState.on !== 'boolean') {
+          return;
+        }
+
+        const currentState = findDeviceById(device.id)?.state ?? {};
+        const hasChanges = Object.entries(parsedState).some(
+          ([key, value]) => currentState?.[key] !== value,
+        );
+
+        if (!hasChanges) {
+          return;
+        }
+
+        await updateDeviceState(device.id, (state) => ({
+          ...state,
+          ...parsedState,
+        }));
+      } catch (error) {
+        console.warn(`Failed to refresh state from Shelly device ${device.id}:`, error);
+      }
+    }),
+  );
+}
+
+export async function refreshAllDeviceStates() {
+  await Promise.all([refreshShellySwitchStates(), refreshRackTemperatureSensor()]);
+}
+
+export class DeviceActionValidationError extends Error {
+  constructor(message, statusCode = 400) {
+    super(message);
+    this.name = 'DeviceActionValidationError';
+    this.statusCode = statusCode;
+  }
+}
+
+async function resolveShellySwitchDesiredState(device, { action, on }) {
+  let desiredOn;
+  let currentOn = device.state?.on ?? false;
+
+  if (device.integration?.type === 'shelly-gen3' && action === 'toggle') {
+    try {
+      const shellyStatus = await fetchShellySwitchState(device);
+      const parsedState = extractShellySwitchState(shellyStatus);
+
+      if (parsedState && typeof parsedState.on === 'boolean') {
+        currentOn = parsedState.on;
+      }
+    } catch (statusError) {
+      console.warn(
+        `Failed to read current state from Shelly device ${device.id}:`,
+        statusError,
+      );
+    }
+  }
+
+  if (action === 'toggle') {
+    desiredOn = !currentOn;
+  } else if (typeof on === 'boolean') {
+    desiredOn = on;
+  } else {
+    throw new DeviceActionValidationError(
+      'Switch actions require { action: "toggle" } or { on: boolean }',
+    );
+  }
+
+  return desiredOn;
+}
+
+async function applyShellySwitchUpdate(device, desiredOn) {
+  const shellyResult = await applyShellySwitchState(device, desiredOn);
+  const immediateState = extractShellySwitchState(shellyResult);
+  let latestState = immediateState ?? null;
+
+  try {
+    const shellyStatus = await fetchShellySwitchState(device);
+    const refreshedState = extractShellySwitchState(shellyStatus);
+    if (refreshedState) {
+      latestState = { ...(latestState ?? {}), ...refreshedState };
+    }
+  } catch (statusError) {
+    console.warn(
+      `Failed to refresh state from Shelly device ${device.id} after update:`,
+      statusError,
+    );
+  }
+
+  const statePatch = { ...(latestState ?? {}) };
+  if (typeof statePatch.on !== 'boolean') {
+    statePatch.on = desiredOn;
+  }
+
+  return updateDeviceState(device.id, (state) => ({
+    ...state,
+    ...statePatch,
+  }));
+}
+
+async function handleSwitchAction(device, payload) {
+  const desiredOn = await resolveShellySwitchDesiredState(device, payload ?? {});
+
+  if (device.integration?.type === 'shelly-gen3') {
+    return applyShellySwitchUpdate(device, desiredOn);
+  }
+
+  return updateDeviceState(device.id, (state) => ({
+    ...state,
+    on: desiredOn,
+  }));
+}
+
+async function handleDimmerAction(device, payload) {
+  const parsedLevel = Number.parseInt(payload?.level, 10);
+  if (!Number.isFinite(parsedLevel) || parsedLevel < 0 || parsedLevel > 100) {
+    throw new DeviceActionValidationError(
+      'Dimmer actions require a level between 0 and 100',
+    );
+  }
+
+  return updateDeviceState(device.id, (state) => ({
+    ...state,
+    level: parsedLevel,
+  }));
+}
+
+export async function performDeviceAction(device, payload) {
+  switch (device.type) {
+    case 'switch':
+      return handleSwitchAction(device, payload);
+    case 'dimmer':
+      return handleDimmerAction(device, payload);
+    case 'sensor':
+      throw new DeviceActionValidationError('Sensor devices are read-only');
+    default:
+      throw new DeviceActionValidationError(
+        `Device type "${device.type}" does not support actions`,
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- extract device state refresh and action logic into a reusable service module
- simplify device routes to delegate side effects and validation to the new service layer

## Testing
- node --check server/services/deviceStateService.js
- node --check server/routes/deviceRoutes.js

------
https://chatgpt.com/codex/tasks/task_e_68e5aa2b12d88331aa8da68520706bf1