### PR TITLE
Improve EventSource stream error handling and remove polling fallback in Devices view

### DIFF
--- a/client/src/views/Devices.vue
+++ b/client/src/views/Devices.vue
@@ -84,10 +84,9 @@ const isLoadingDevices = ref(false)
 const errorMessage = ref('')
 const pendingDeviceIds = ref(new Set())
 
-const AUTO_REFRESH_INTERVAL_MS = 5000
-let autoRefreshTimerId = null
+const STREAM_ERROR_GRACE_PERIOD_MS = 3000
+let streamErrorTimerId = null
 let deviceStream = null
-let fallbackActive = false
 const STREAM_ENDPOINT = '/api/devices/stream'
 
 const isDevicePending = (deviceId) => pendingDeviceIds.value.has(deviceId)
@@ -177,32 +176,6 @@ const updateDimmer = async (device, level) => {
 
 const formatSensorReading = (state) => formatSensorReadingImpl(state)
 
-const stopAutoRefresh = () => {
-  fallbackActive = false
-  if (autoRefreshTimerId !== null && typeof window !== 'undefined') {
-    window.clearInterval(autoRefreshTimerId)
-    autoRefreshTimerId = null
-  }
-}
-
-const startAutoRefresh = () => {
-  if (fallbackActive) {
-    return
-  }
-  stopAutoRefresh()
-  fallbackActive = true
-
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return
-  }
-
-  autoRefreshTimerId = window.setInterval(() => {
-    if (!document.hidden) {
-      fetchDevices()
-    }
-  }, AUTO_REFRESH_INTERVAL_MS)
-}
-
 const closeDeviceStream = () => {
   if (typeof window === 'undefined' || !deviceStream) {
     return
@@ -237,15 +210,32 @@ const handleDeviceEvent = (event) => {
 }
 
 const handleDeviceStreamOpen = () => {
-  stopAutoRefresh()
+  clearStreamErrorTimer()
   errorMessage.value = ''
 }
 
 const handleDeviceStreamError = () => {
-  if (!fallbackActive) {
-    errorMessage.value = 'Live device stream interrupted. Switching to fallback polling.'
-    startAutoRefresh()
+  if (streamErrorTimerId !== null || typeof window === 'undefined') {
+    return
   }
+
+  streamErrorTimerId = window.setTimeout(() => {
+    streamErrorTimerId = null
+
+    if (!deviceStream || deviceStream.readyState === window.EventSource.OPEN) {
+      return
+    }
+
+    errorMessage.value = 'Live device stream interrupted. Waiting for reconnect.'
+  }, STREAM_ERROR_GRACE_PERIOD_MS)
+}
+
+const clearStreamErrorTimer = () => {
+  if (streamErrorTimerId === null || typeof window === 'undefined') {
+    return
+  }
+  window.clearTimeout(streamErrorTimerId)
+  streamErrorTimerId = null
 }
 
 const initializeDeviceStream = () => {
@@ -254,8 +244,7 @@ const initializeDeviceStream = () => {
   }
 
   if (typeof window.EventSource !== 'function') {
-    errorMessage.value = 'Live device streaming is unavailable in this browser. Using fallback polling.'
-    startAutoRefresh()
+    errorMessage.value = 'Live device streaming is unavailable in this browser.'
     return
   }
 
@@ -266,32 +255,14 @@ const initializeDeviceStream = () => {
   deviceStream.addEventListener('error', handleDeviceStreamError)
 }
 
-const handleVisibilityChange = () => {
-  if (typeof document === 'undefined') {
-    return
-  }
-
-  if (!document.hidden && fallbackActive) {
-    fetchDevices()
-  }
-}
-
 onMounted(() => {
   fetchDevices()
   initializeDeviceStream()
-
-  if (typeof document !== 'undefined') {
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-  }
 })
 
 onUnmounted(() => {
-  stopAutoRefresh()
+  clearStreamErrorTimer()
   closeDeviceStream()
-
-  if (typeof document !== 'undefined') {
-    document.removeEventListener('visibilitychange', handleVisibilityChange)
-  }
 })
 </script>
 


### PR DESCRIPTION
### Motivation
- Reduce noisy immediate fallbacks and avoid unnecessary polling when the SSE device stream has transient interruptions by debouncing error reporting and simplifying stream lifecycle handling.
- Remove legacy visibility-based polling fallback to prefer a cleaner EventSource-first approach.

### Description
- Removed the polling fallback and visibility handlers by deleting `AUTO_REFRESH_INTERVAL_MS`, `fallbackActive`, `startAutoRefresh`, `stopAutoRefresh`, and the `visibilitychange` listener usage. 
- Added `STREAM_ERROR_GRACE_PERIOD_MS` and `streamErrorTimerId` to debounce stream errors and implemented `clearStreamErrorTimer()` to cancel pending error timers. 
- Updated `handleDeviceStreamError` to schedule a delayed message only if the stream remains closed after the grace period and updated `handleDeviceStreamOpen` to clear any pending error timer. 
- Adjusted `initializeDeviceStream` to change the unsupported browser message to `"Live device streaming is unavailable in this browser."` and no longer trigger fallback polling.

### Testing
- Ran the frontend test suite and linters against the modified files and all tests passed.
- Manually exercised the devices view in a browser to verify that transient SSE errors do not immediately show an error and that the stream open handler clears pending error timers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9d69d3408331991499773e63b359)