### PR TITLE
Replace manual view switching with Vue Router

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "axios": "^1.12.2",
         "chart.js": "^4.5.0",
-        "vue": "^3.5.21"
+        "vue": "^3.5.21",
+        "vue-router": "^4.6.4"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
@@ -1073,6 +1074,12 @@
         "@vue/compiler-dom": "3.5.22",
         "@vue/shared": "3.5.22"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.22",
@@ -2613,6 +2620,21 @@
       "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "axios": "^1.12.2",
     "chart.js": "^4.5.0",
-    "vue": "^3.5.21"
+    "vue": "^3.5.21",
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,16 +1,6 @@
 <script setup>
-import { ref } from 'vue'
-import Dashboard from './views/Dashboard.vue'
-import Devices from './views/Devices.vue'
+import { RouterLink, RouterView } from 'vue-router'
 import RoomPiLogo from './assets/roompi-logo.svg'
-
-const activeView = ref('devices')
-
-const setView = (view) => {
-  activeView.value = view
-}
-
-const isActive = (view) => activeView.value === view
 </script>
 
 <template>
@@ -20,29 +10,24 @@ const isActive = (view) => activeView.value === view
       <h1 class="app-header__title">RoomPi</h1>
     </header>
     <nav class="nav">
-      <button
-        type="button"
+      <RouterLink
+        to="/devices"
         class="nav__button"
-        :class="{ 'nav__button--active': isActive('devices') }"
-        @click="setView('devices')"
-        :aria-pressed="isActive('devices')"
+        active-class="nav__button--active"
       >
         Devices
-      </button>
-      <button
-        type="button"
+      </RouterLink>
+      <RouterLink
+        to="/dashboard"
         class="nav__button"
-        :class="{ 'nav__button--active': isActive('dashboard') }"
-        @click="setView('dashboard')"
-        :aria-pressed="isActive('dashboard')"
+        active-class="nav__button--active"
       >
         Dashboard
-      </button>
+      </RouterLink>
     </nav>
 
     <section class="view-container">
-      <Devices v-if="isActive('devices')" />
-      <Dashboard v-else />
+      <RouterView />
     </section>
   </main>
 </template>
@@ -97,6 +82,7 @@ const isActive = (view) => activeView.value === view
   cursor: pointer;
   transition: transform 150ms ease-in-out, box-shadow 150ms ease-in-out;
   box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);
+  text-decoration: none;
 }
 
 .nav__button:hover {

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
+import router from './router'
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -1,0 +1,27 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import Devices from './views/Devices.vue'
+import Dashboard from './views/Dashboard.vue'
+
+const routes = [
+  {
+    path: '/',
+    redirect: '/devices',
+  },
+  {
+    path: '/devices',
+    name: 'devices',
+    component: Devices,
+  },
+  {
+    path: '/dashboard',
+    name: 'dashboard',
+    component: Dashboard,
+  },
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})
+
+export default router


### PR DESCRIPTION
### Motivation
- Replace local manual view toggling with route-based navigation to make navigation stateful, bookmarkable, and align with standard Vue patterns.

### Description
- Replace `activeView` state and manual `setView`/`v-if` switching in `client/src/App.vue` with `RouterLink` and `RouterView`.
- Add `client/src/router.js` with routes for `/devices` and `/dashboard` and a redirect from `/` to `/devices`.
- Wire the router into the app bootstrap in `client/src/main.js` via `createApp(App).use(router)`.
- Add `vue-router` to `client/package.json` and update the lockfile to include the new dependency.

### Testing
- Ran `cd client && npm install` to add `vue-router` and update lockfile, which completed successfully.
- Ran `cd client && npm run build`, which built the production assets successfully.
- Ran `cd client && npm test`, and all tests passed (`6` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa47d81dc8331aa43bbf3bdd4fc37)