### PR TITLE
Persist metrics history in lightweight SQLite storage

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -22,6 +22,7 @@ uvicorn main:app --host 0.0.0.0 --port 3000
 - `PORT` (domyślnie `3000`)
 - `SAMPLE_INTERVAL_MS` (domyślnie `1000`)
 - `MAX_METRIC_SAMPLES` (domyślnie `1000`)
+- `METRICS_DB_PATH` (domyślnie `server/metrics.sqlite3`)
 - `MQTT_ENABLED` (`true/false`, domyślnie `false`)
 - `MQTT_BROKER_HOST` (domyślnie `127.0.0.1`)
 - `MQTT_BROKER_PORT` (domyślnie `1883`)
@@ -38,6 +39,12 @@ uvicorn main:app --host 0.0.0.0 --port 3000
 - `GET /api/devices`
 - `POST /api/devices/{id}/actions`
 - `POST /api/devices/{id}/state` (aktualizacja stanu sensora)
+
+## Historia metryk
+
+- Historia metryk nie jest już trzymana w RAM (`deque`), tylko w lekkiej bazie SQLite.
+- Plik bazy domyślnie: `server/metrics.sqlite3` (zmienisz przez `METRICS_DB_PATH`).
+- Po przekroczeniu `MAX_METRIC_SAMPLES` najstarsze rekordy są automatycznie usuwane.
 
 ## Integracja z Node-RED + Mosquitto (MQTT)
 

--- a/server/config_py.py
+++ b/server/config_py.py
@@ -9,6 +9,7 @@ DEVICES_FILE_PATH = BASE_DIR / "devices.json"
 PORT = int(os.environ.get("PORT", 3000))
 SAMPLE_INTERVAL_MS = int(os.environ.get("SAMPLE_INTERVAL_MS", 1000))
 MAX_METRIC_SAMPLES = int(os.environ.get("MAX_METRIC_SAMPLES", 1000))
+METRICS_DB_PATH = Path(os.environ.get("METRICS_DB_PATH", BASE_DIR / "metrics.sqlite3"))
 
 MQTT_ENABLED = os.environ.get("MQTT_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
 MQTT_BROKER_HOST = os.environ.get("MQTT_BROKER_HOST", "127.0.0.1")

--- a/server/metrics_service_py.py
+++ b/server/metrics_service_py.py
@@ -1,14 +1,68 @@
 from __future__ import annotations
 
 import asyncio
-from collections import deque
 from datetime import datetime, timezone
+import json
+import sqlite3
+import threading
 import psutil
 
-from config_py import MAX_METRIC_SAMPLES, SAMPLE_INTERVAL_MS
+from config_py import MAX_METRIC_SAMPLES, METRICS_DB_PATH, SAMPLE_INTERVAL_MS
 
-_metrics_history = deque(maxlen=MAX_METRIC_SAMPLES)
 _subscribers: set[asyncio.Queue] = set()
+_db_lock = threading.Lock()
+
+
+def _connect() -> sqlite3.Connection:
+    return sqlite3.connect(METRICS_DB_PATH)
+
+
+def _init_db() -> None:
+    with _db_lock, _connect() as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS metric_samples (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                payload TEXT NOT NULL
+            )
+            """
+        )
+        connection.commit()
+
+
+def _store_sample(sample: dict) -> None:
+    serialized = json.dumps(sample)
+    timestamp = sample.get("timestamp") or datetime.now(timezone.utc).isoformat()
+    with _db_lock, _connect() as connection:
+        connection.execute(
+            "INSERT INTO metric_samples (timestamp, payload) VALUES (?, ?)",
+            (timestamp, serialized),
+        )
+        connection.execute(
+            """
+            DELETE FROM metric_samples
+            WHERE id NOT IN (
+                SELECT id FROM metric_samples
+                ORDER BY id DESC
+                LIMIT ?
+            )
+            """,
+            (MAX_METRIC_SAMPLES,),
+        )
+        connection.commit()
+
+
+def _load_samples() -> list[dict]:
+    with _db_lock, _connect() as connection:
+        rows = connection.execute(
+            """
+            SELECT payload
+            FROM metric_samples
+            ORDER BY id ASC
+            """
+        ).fetchall()
+    return [json.loads(payload) for (payload,) in rows]
 
 
 def _extract_temperature_metrics() -> dict:
@@ -67,14 +121,14 @@ def metrics_history() -> dict:
     return {
         "intervalMs": SAMPLE_INTERVAL_MS,
         "maxSamples": MAX_METRIC_SAMPLES,
-        "samples": list(_metrics_history),
+        "samples": _load_samples(),
     }
 
 
 async def sample_loop():
     while True:
         sample = gather_metrics()
-        _metrics_history.append(sample)
+        _store_sample(sample)
         for queue in list(_subscribers):
             await queue.put(sample)
         await asyncio.sleep(SAMPLE_INTERVAL_MS / 1000)
@@ -89,3 +143,6 @@ async def subscribe():
             yield item
     finally:
         _subscribers.discard(queue)
+
+
+_init_db()

--- a/server/test_metrics_service_py.py
+++ b/server/test_metrics_service_py.py
@@ -35,3 +35,19 @@ def test_extract_temperature_metrics_collects_main_and_max(monkeypatch):
     assert metrics["main"] == 51.2
     assert metrics["cores"] == [51.2, 53.8, 47.1]
     assert metrics["max"] == 95.0
+
+
+def test_metrics_history_uses_sqlite_and_respects_limit(monkeypatch, tmp_path):
+    db_path = tmp_path / "metrics_test.sqlite3"
+    monkeypatch.setattr(metrics_service_py, "METRICS_DB_PATH", db_path)
+    monkeypatch.setattr(metrics_service_py, "MAX_METRIC_SAMPLES", 2)
+    metrics_service_py._init_db()
+
+    metrics_service_py._store_sample({"timestamp": "2026-01-01T00:00:00+00:00", "cpu": {"load": 10}})
+    metrics_service_py._store_sample({"timestamp": "2026-01-01T00:00:01+00:00", "cpu": {"load": 20}})
+    metrics_service_py._store_sample({"timestamp": "2026-01-01T00:00:02+00:00", "cpu": {"load": 30}})
+
+    history = metrics_service_py.metrics_history()
+
+    assert history["maxSamples"] == 2
+    assert [sample["cpu"]["load"] for sample in history["samples"]] == [20, 30]


### PR DESCRIPTION
### Motivation
- Replace the in-memory `deque` metrics history with a lightweight on-disk store so metric samples survive process restarts and memory usage is bounded by pruning to `MAX_METRIC_SAMPLES`.
- Make the metrics storage location configurable via an environment variable to allow custom deployment paths.

### Description
- Added `METRICS_DB_PATH` configuration in `server/config_py.py` (default `server/metrics.sqlite3`).
- Replaced the `deque`-based `_metrics_history` with SQLite-backed helpers in `server/metrics_service_py.py`: `_connect`, `_init_db`, `_store_sample`, `_load_samples`, and a `_db_lock` for thread-safety, and call `_init_db()` at module import.
- Updated `metrics_history()` to return samples from SQLite and updated `sample_loop()` to persist new samples with pruning to keep only the latest `MAX_METRIC_SAMPLES`.
- Added `test_metrics_history_uses_sqlite_and_respects_limit` to `server/test_metrics_service_py.py` and documented the change in `server/README.md`.

### Testing
- Ran `pytest -q server/test_metrics_service_py.py` which passed (`3 passed`).
- Ran full server test suite `pytest -q server` which passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa5b5dbd88331a4661bb08b841d08)