### PR TITLE
Add admin authentication, login view and protected admin panel with route guards

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,6 +1,17 @@
 <script setup>
-import { RouterLink, RouterView } from 'vue-router'
+import { computed } from 'vue'
+import { RouterLink, RouterView, useRoute } from 'vue-router'
 import RoomPiLogo from './assets/roompi-logo.svg'
+import { useAdminAuth } from './auth'
+
+const route = useRoute()
+const { isAuthenticated, logout } = useAdminAuth()
+
+const isAdminRoute = computed(() => route.path.startsWith('/admin'))
+
+const handleLogout = () => {
+  logout()
+}
 </script>
 
 <template>
@@ -24,6 +35,30 @@ import RoomPiLogo from './assets/roompi-logo.svg'
       >
         Dashboard
       </RouterLink>
+      <RouterLink
+        v-if="isAuthenticated"
+        to="/admin"
+        class="nav__button"
+        active-class="nav__button--active"
+      >
+        Admin
+      </RouterLink>
+      <RouterLink
+        v-else
+        to="/admin/login"
+        class="nav__button"
+        active-class="nav__button--active"
+      >
+        Admin login
+      </RouterLink>
+      <button
+        v-if="isAuthenticated && isAdminRoute"
+        type="button"
+        class="nav__button nav__button--danger"
+        @click="handleLogout"
+      >
+        Wyloguj
+      </button>
     </nav>
 
     <section class="view-container">
@@ -95,6 +130,11 @@ import RoomPiLogo from './assets/roompi-logo.svg'
   box-shadow: 0 15px 35px rgba(37, 99, 235, 0.35);
 }
 
+.nav__button--danger {
+  background: #dc2626;
+  color: #fff;
+}
+
 .view-container {
   flex: 1;
 }
@@ -121,6 +161,10 @@ import RoomPiLogo from './assets/roompi-logo.svg'
   .nav__button--active {
     background: #2563eb;
     box-shadow: 0 20px 45px rgba(37, 99, 235, 0.55);
+  }
+
+  .nav__button--danger {
+    background: #dc2626;
   }
 }
 </style>

--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -1,0 +1,64 @@
+import { computed, ref } from 'vue'
+import adminCredentials from './config/adminCredentials.json'
+
+const SESSION_STORAGE_KEY = 'roompi-admin-authenticated'
+
+const isAuthenticated = ref(false)
+
+const isBrowserEnvironment =
+  typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined'
+
+const readStoredState = () => {
+  if (!isBrowserEnvironment) {
+    return false
+  }
+
+  return window.sessionStorage.getItem(SESSION_STORAGE_KEY) === 'true'
+}
+
+const persistState = (value) => {
+  if (!isBrowserEnvironment) {
+    return
+  }
+
+  window.sessionStorage.setItem(SESSION_STORAGE_KEY, value ? 'true' : 'false')
+}
+
+isAuthenticated.value = readStoredState()
+
+const getCredentials = () => {
+  if (!adminCredentials || typeof adminCredentials !== 'object') {
+    return {
+      username: '',
+      password: '',
+    }
+  }
+
+  return {
+    username: adminCredentials.username ?? '',
+    password: adminCredentials.password ?? '',
+  }
+}
+
+export const useAdminAuth = () => {
+  const login = ({ username, password }) => {
+    const credentials = getCredentials()
+    const loginSucceeded =
+      username === credentials.username && password === credentials.password
+
+    isAuthenticated.value = loginSucceeded
+    persistState(loginSucceeded)
+    return loginSucceeded
+  }
+
+  const logout = () => {
+    isAuthenticated.value = false
+    persistState(false)
+  }
+
+  return {
+    isAuthenticated: computed(() => isAuthenticated.value),
+    login,
+    logout,
+  }
+}

--- a/client/src/config/adminCredentials.json
+++ b/client/src/config/adminCredentials.json
@@ -1,0 +1,4 @@
+{
+  "username": "michalx106",
+  "password": "Kowies1234"
+}

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -1,6 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Devices from './views/Devices.vue'
 import Dashboard from './views/Dashboard.vue'
+import AdminLogin from './views/AdminLogin.vue'
+import AdminPanel from './views/AdminPanel.vue'
+import { useAdminAuth } from './auth'
 
 const routes = [
   {
@@ -17,11 +20,41 @@ const routes = [
     name: 'dashboard',
     component: Dashboard,
   },
+  {
+    path: '/admin/login',
+    name: 'admin-login',
+    component: AdminLogin,
+    meta: {
+      requiresGuest: true,
+    },
+  },
+  {
+    path: '/admin',
+    name: 'admin',
+    component: AdminPanel,
+    meta: {
+      requiresAdmin: true,
+    },
+  },
 ]
 
 const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+router.beforeEach((to) => {
+  const { isAuthenticated } = useAdminAuth()
+
+  if (to.meta.requiresAdmin && !isAuthenticated.value) {
+    return { path: '/admin/login', query: { redirect: to.fullPath } }
+  }
+
+  if (to.meta.requiresGuest && isAuthenticated.value) {
+    return '/admin'
+  }
+
+  return true
 })
 
 export default router

--- a/client/src/views/AdminLogin.vue
+++ b/client/src/views/AdminLogin.vue
@@ -1,0 +1,117 @@
+<template>
+  <div class="admin-login">
+    <section class="admin-login__card">
+      <h1>Admin Login</h1>
+      <p>Zaloguj się, aby otworzyć panel administracyjny.</p>
+
+      <form class="admin-login__form" @submit.prevent="submitLogin">
+        <label for="admin-username">Login</label>
+        <input
+          id="admin-username"
+          v-model.trim="username"
+          type="text"
+          autocomplete="username"
+          required
+        />
+
+        <label for="admin-password">Hasło</label>
+        <input
+          id="admin-password"
+          v-model="password"
+          type="password"
+          autocomplete="current-password"
+          required
+        />
+
+        <button type="submit">Zaloguj</button>
+      </form>
+
+      <p v-if="errorMessage" class="admin-login__error" role="alert">{{ errorMessage }}</p>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAdminAuth } from '../auth'
+
+const username = ref('')
+const password = ref('')
+const errorMessage = ref('')
+const router = useRouter()
+const route = useRoute()
+const { login } = useAdminAuth()
+
+const submitLogin = () => {
+  errorMessage.value = ''
+
+  const isSuccess = login({
+    username: username.value,
+    password: password.value,
+  })
+
+  if (!isSuccess) {
+    errorMessage.value = 'Niepoprawny login lub hasło.'
+    return
+  }
+
+  const redirectPath = typeof route.query.redirect === 'string' ? route.query.redirect : '/admin'
+  router.push(redirectPath)
+}
+</script>
+
+<style scoped>
+.admin-login {
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.admin-login__card {
+  width: min(420px, 100%);
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.1);
+}
+
+.admin-login__form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.admin-login__form input {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.6rem;
+  padding: 0.7rem;
+}
+
+.admin-login__form button {
+  border: none;
+  border-radius: 0.6rem;
+  background: #2563eb;
+  color: white;
+  padding: 0.7rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.admin-login__error {
+  margin-top: 0.8rem;
+  color: #b91c1c;
+}
+
+@media (prefers-color-scheme: dark) {
+  .admin-login__card {
+    background: rgba(15, 23, 42, 0.9);
+    box-shadow: 0 16px 30px rgba(2, 6, 23, 0.6);
+  }
+
+  .admin-login__form input {
+    border-color: #334155;
+    background: #0f172a;
+    color: #e2e8f0;
+  }
+}
+</style>

--- a/client/src/views/AdminPanel.vue
+++ b/client/src/views/AdminPanel.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="admin-panel">
+    <section class="admin-panel__card">
+      <h1>Panel administratora</h1>
+      <p>Masz dostęp do sekcji chronionej.</p>
+
+      <ul>
+        <li>Monitoruj urządzenia i metryki systemu.</li>
+        <li>Dodaj własne akcje administracyjne w tym widoku.</li>
+      </ul>
+
+      <div class="admin-panel__actions">
+        <RouterLink to="/devices" class="admin-panel__action-link">Przejdź do Devices</RouterLink>
+        <RouterLink to="/dashboard" class="admin-panel__action-link">Przejdź do Dashboard</RouterLink>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { RouterLink } from 'vue-router'
+</script>
+
+<style scoped>
+.admin-panel {
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.admin-panel__card {
+  width: min(780px, 100%);
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.1);
+}
+
+.admin-panel__actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.admin-panel__action-link {
+  background: #2563eb;
+  color: white;
+  padding: 0.65rem 1rem;
+  border-radius: 0.65rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+@media (prefers-color-scheme: dark) {
+  .admin-panel__card {
+    background: rgba(15, 23, 42, 0.9);
+    box-shadow: 0 16px 30px rgba(2, 6, 23, 0.6);
+  }
+}
+</style>


### PR DESCRIPTION
### Motivation
- Add a simple client-side admin area to allow privileged access to management features.  
- Provide an authentication flow with login, logout and route protection for the `/admin` section.  

### Description
- Introduce a lightweight auth composable `useAdminAuth` in `client/src/auth.js` that manages login state, persists it to `sessionStorage`, and exposes `login`/`logout` functions.  
- Add `client/src/config/adminCredentials.json` to store admin credentials used by the local auth composable.  
- Add new views `AdminLogin.vue` and `AdminPanel.vue` under `client/src/views/` to implement the login form and the protected admin panel UI.  
- Wire the admin routes into `client/src/router.js` with `meta` flags and a `beforeEach` guard that redirects unauthenticated users to `/admin/login` and prevents logged-in admins from visiting the guest login page.  
- Update `client/src/App.vue` to show an `Admin` or `Admin login` navigation link depending on authentication state, and add a `Wyloguj` logout button on admin routes; add corresponding styles for a danger button.  

### Testing
- Ran a production build with `npm run build` which completed successfully.  
- No automated unit tests were added with this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa74cc5c883319cb8b5905743fe37)