### PR TITLE
ci: bump actions/checkout to v5 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Sync repo
         run: |


### PR DESCRIPTION
### Motivation
- Replace `actions/checkout@v4` with `actions/checkout@v5` in `./.github/workflows/deploy.yml` to avoid the Node.js 20 deprecation path and use a Node.js 24-compatible checkout action.

### Description
- Updated `./.github/workflows/deploy.yml` to use `actions/checkout@v5` instead of `actions/checkout@v4`.

### Testing
- Validated the change with `git diff .github/workflows/deploy.yml`, inspected the updated file with `nl`/`sed`, and committed the change; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa94c893c8331b1cb293626c6774f)