### PR TITLE
Add admin device CRUD management (API + UI + tests)

### DIFF
--- a/client/src/views/AdminPanel.vue
+++ b/client/src/views/AdminPanel.vue
@@ -2,12 +2,92 @@
   <div class="admin-panel">
     <section class="admin-panel__card">
       <h1>Panel administratora</h1>
-      <p>Masz dostęp do sekcji chronionej.</p>
+      <p>Zarządzaj urządzeniami: dodawaj, edytuj i usuwaj wpisy w konfiguracji backendu.</p>
 
-      <ul>
-        <li>Monitoruj urządzenia i metryki systemu.</li>
-        <li>Dodaj własne akcje administracyjne w tym widoku.</li>
-      </ul>
+      <p v-if="errorMessage" class="admin-panel__error" role="alert">{{ errorMessage }}</p>
+      <p v-if="successMessage" class="admin-panel__success" role="status">{{ successMessage }}</p>
+
+      <form class="device-form" @submit.prevent="saveDevice">
+        <h2>{{ editingDeviceId ? 'Edytuj urządzenie' : 'Dodaj urządzenie' }}</h2>
+
+        <div class="form-grid">
+          <label>
+            ID
+            <input v-model.trim="form.id" :disabled="Boolean(editingDeviceId)" required placeholder="np. desk-light" />
+          </label>
+
+          <label>
+            Nazwa
+            <input v-model.trim="form.name" required placeholder="np. Lampka biurkowa" />
+          </label>
+
+          <label>
+            Typ
+            <select v-model="form.type" required>
+              <option value="switch">switch</option>
+              <option value="dimmer">dimmer</option>
+              <option value="sensor">sensor</option>
+              <option value="camera">camera</option>
+            </select>
+          </label>
+
+          <label>
+            Topic MQTT (opcjonalnie)
+            <input v-model.trim="form.topic" placeholder="np. roompi/devices/desk-light/state" />
+          </label>
+
+          <label v-if="form.type === 'switch'">
+            Stan (on/off)
+            <select v-model="form.state.on">
+              <option :value="true">on</option>
+              <option :value="false">off</option>
+            </select>
+          </label>
+
+          <label v-else-if="form.type === 'dimmer'">
+            Poziom (0-100)
+            <input v-model.number="form.state.level" type="number" min="0" max="100" required />
+          </label>
+
+          <label v-else>
+            State JSON (opcjonalnie)
+            <textarea
+              v-model="rawStateJson"
+              rows="4"
+              placeholder='np. {"temperatureC": 23.4, "humidity": 45}'
+            />
+          </label>
+        </div>
+
+        <div class="device-form__actions">
+          <button type="submit">{{ editingDeviceId ? 'Zapisz zmiany' : 'Dodaj urządzenie' }}</button>
+          <button v-if="editingDeviceId" type="button" class="secondary" @click="resetForm">Anuluj edycję</button>
+        </div>
+      </form>
+
+      <h2>Lista urządzeń</h2>
+      <table v-if="devices.length" class="device-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Nazwa</th>
+            <th>Typ</th>
+            <th>Akcje</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="device in devices" :key="device.id">
+            <td>{{ device.id }}</td>
+            <td>{{ device.name || '—' }}</td>
+            <td>{{ device.type }}</td>
+            <td class="device-table__actions">
+              <button type="button" class="secondary" @click="startEdit(device)">Edytuj</button>
+              <button type="button" class="danger" @click="removeDevice(device)">Usuń</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-else>Brak urządzeń.</p>
 
       <div class="admin-panel__actions">
         <RouterLink to="/devices" class="admin-panel__action-link">Przejdź do Devices</RouterLink>
@@ -18,7 +98,137 @@
 </template>
 
 <script setup>
+import axios from 'axios'
+import { onMounted, reactive, ref } from 'vue'
 import { RouterLink } from 'vue-router'
+
+const devices = ref([])
+const errorMessage = ref('')
+const successMessage = ref('')
+const editingDeviceId = ref('')
+const rawStateJson = ref('')
+
+const form = reactive({
+  id: '',
+  name: '',
+  type: 'switch',
+  topic: '',
+  state: {
+    on: false,
+    level: 0,
+  },
+})
+
+const resetForm = () => {
+  editingDeviceId.value = ''
+  rawStateJson.value = ''
+  form.id = ''
+  form.name = ''
+  form.type = 'switch'
+  form.topic = ''
+  form.state = { on: false, level: 0 }
+}
+
+const fetchDevices = async () => {
+  const { data } = await axios.get('/api/devices')
+  devices.value = Array.isArray(data) ? data : []
+}
+
+const buildPayload = () => {
+  const payload = {
+    name: form.name,
+    type: form.type,
+  }
+
+  if (!editingDeviceId.value) {
+    payload.id = form.id
+  }
+
+  if (form.topic) {
+    payload.topic = form.topic
+  }
+
+  if (form.type === 'switch') {
+    payload.state = { on: Boolean(form.state.on) }
+    return payload
+  }
+
+  if (form.type === 'dimmer') {
+    payload.state = { level: Number(form.state.level) }
+    return payload
+  }
+
+  if (rawStateJson.value.trim()) {
+    payload.state = JSON.parse(rawStateJson.value)
+  }
+
+  return payload
+}
+
+const saveDevice = async () => {
+  errorMessage.value = ''
+  successMessage.value = ''
+
+  try {
+    const payload = buildPayload()
+
+    if (editingDeviceId.value) {
+      await axios.put(`/api/admin/devices/${editingDeviceId.value}`, payload)
+      successMessage.value = 'Zapisano zmiany urządzenia.'
+    } else {
+      await axios.post('/api/admin/devices', payload)
+      successMessage.value = 'Dodano nowe urządzenie.'
+    }
+
+    await fetchDevices()
+    resetForm()
+  } catch (error) {
+    errorMessage.value = error?.response?.data?.detail ?? error?.message ?? 'Nie udało się zapisać urządzenia.'
+  }
+}
+
+const startEdit = (device) => {
+  editingDeviceId.value = device.id
+  form.id = device.id
+  form.name = device.name || ''
+  form.type = device.type || 'switch'
+  form.topic = device.topic || ''
+
+  if (form.type === 'switch') {
+    form.state = { on: Boolean(device.state?.on) }
+    rawStateJson.value = ''
+  } else if (form.type === 'dimmer') {
+    form.state = { level: Number(device.state?.level ?? 0) }
+    rawStateJson.value = ''
+  } else {
+    form.state = { on: false, level: 0 }
+    rawStateJson.value = JSON.stringify(device.state || {}, null, 2)
+  }
+}
+
+const removeDevice = async (device) => {
+  errorMessage.value = ''
+  successMessage.value = ''
+
+  try {
+    await axios.delete(`/api/admin/devices/${device.id}`)
+    if (editingDeviceId.value === device.id) {
+      resetForm()
+    }
+    await fetchDevices()
+    successMessage.value = `Usunięto urządzenie: ${device.name || device.id}.`
+  } catch (error) {
+    errorMessage.value = error?.response?.data?.detail ?? error?.message ?? 'Nie udało się usunąć urządzenia.'
+  }
+}
+
+onMounted(async () => {
+  try {
+    await fetchDevices()
+  } catch (error) {
+    errorMessage.value = error?.response?.data?.detail ?? error?.message ?? 'Nie udało się pobrać urządzeń.'
+  }
+})
 </script>
 
 <style scoped>
@@ -29,33 +239,120 @@ import { RouterLink } from 'vue-router'
 }
 
 .admin-panel__card {
-  width: min(780px, 100%);
+  width: min(980px, 100%);
   background: white;
   border-radius: 1rem;
   padding: 1.5rem;
   box-shadow: 0 16px 30px rgba(15, 23, 42, 0.1);
 }
 
-.admin-panel__actions {
-  margin-top: 1rem;
+.admin-panel__error {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.admin-panel__success {
+  color: #15803d;
+  font-weight: 600;
+}
+
+.device-form {
+  margin: 1rem 0 1.5rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.8rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.9rem;
+}
+
+label {
   display: flex;
-  gap: 0.8rem;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.6rem;
+}
+
+.device-form__actions,
+.admin-panel__actions,
+.device-table__actions {
+  display: flex;
+  gap: 0.6rem;
   flex-wrap: wrap;
 }
 
+button,
 .admin-panel__action-link {
   background: #2563eb;
   color: white;
-  padding: 0.65rem 1rem;
-  border-radius: 0.65rem;
+  border: none;
+  padding: 0.55rem 0.9rem;
+  border-radius: 0.6rem;
   text-decoration: none;
-  font-weight: 600;
+  cursor: pointer;
+}
+
+button.secondary {
+  background: #475569;
+}
+
+button.danger {
+  background: #dc2626;
+}
+
+.device-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.6rem;
+}
+
+.device-table th,
+.device-table td {
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  padding: 0.6rem 0.4rem;
+}
+
+.admin-panel__actions {
+  margin-top: 1rem;
 }
 
 @media (prefers-color-scheme: dark) {
   .admin-panel__card {
     background: rgba(15, 23, 42, 0.9);
     box-shadow: 0 16px 30px rgba(2, 6, 23, 0.6);
+  }
+
+  input,
+  select,
+  textarea {
+    background: rgba(15, 23, 42, 0.8);
+    color: #f8fafc;
+    border-color: rgba(148, 163, 184, 0.4);
+  }
+
+  .device-form,
+  .device-table th,
+  .device-table td {
+    border-color: rgba(148, 163, 184, 0.4);
   }
 }
 </style>

--- a/client/src/views/Devices.vue
+++ b/client/src/views/Devices.vue
@@ -134,6 +134,11 @@ const fetchDevices = async () => {
 }
 
 const updateDeviceInList = (nextDevice) => {
+  if (nextDevice?._deleted === true) {
+    devices.value = devices.value.filter((device) => device.id !== nextDevice?.id)
+    return
+  }
+
   if (!shouldDisplayDevice(nextDevice)) {
     devices.value = devices.value.filter((device) => device.id !== nextDevice?.id)
     return

--- a/server/README.md
+++ b/server/README.md
@@ -39,6 +39,9 @@ uvicorn main:app --host 0.0.0.0 --port 3000
 - `GET /api/devices`
 - `POST /api/devices/{id}/actions`
 - `POST /api/devices/{id}/state` (aktualizacja stanu sensora)
+- `POST /api/admin/devices` (dodanie urządzenia)
+- `PUT /api/admin/devices/{id}` (edycja urządzenia)
+- `DELETE /api/admin/devices/{id}` (usunięcie urządzenia)
 
 ## Historia metryk
 

--- a/server/device_service_py.py
+++ b/server/device_service_py.py
@@ -63,6 +63,114 @@ class DeviceService:
                 return device
         return None
 
+    @staticmethod
+    def _validate_device_identity(payload: dict, require_id: bool = True) -> dict:
+        device_id = payload.get("id")
+        if require_id:
+            if not isinstance(device_id, str) or not device_id.strip():
+                raise DeviceActionValidationError('Device requires non-empty string field "id"')
+            device_id = device_id.strip()
+
+        name = payload.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise DeviceActionValidationError('Device requires non-empty string field "name"')
+
+        dtype = payload.get("type")
+        allowed_types = {"switch", "dimmer", "sensor", "camera"}
+        if dtype not in allowed_types:
+            raise DeviceActionValidationError(
+                f'Device type must be one of: {", ".join(sorted(allowed_types))}'
+            )
+
+        topic = payload.get("topic")
+        if topic is not None and not isinstance(topic, str):
+            raise DeviceActionValidationError('Device field "topic" must be a string when provided')
+
+        state_payload = payload.get("state")
+        if state_payload is not None and not isinstance(state_payload, dict):
+            raise DeviceActionValidationError('Device field "state" must be an object when provided')
+
+        result = {
+            "name": name.strip(),
+            "type": dtype,
+            "state": dict(state_payload or {}),
+        }
+        if require_id:
+            result["id"] = device_id
+        if isinstance(topic, str) and topic.strip():
+            result["topic"] = topic.strip()
+        return result
+
+    @staticmethod
+    def _normalize_state(dtype: str, state: dict) -> dict:
+        normalized = dict(state or {})
+        if dtype == "switch":
+            on = normalized.get("on", False)
+            if not isinstance(on, bool):
+                raise DeviceActionValidationError('Switch state requires boolean field "on"')
+            normalized["on"] = on
+        elif dtype == "dimmer":
+            level = normalized.get("level", 0)
+            if not isinstance(level, int) or level < 0 or level > 100:
+                raise DeviceActionValidationError('Dimmer state requires integer field "level" between 0 and 100')
+            normalized["level"] = level
+        return normalized
+
+    def create_device(self, payload: dict):
+        if not isinstance(payload, dict):
+            raise DeviceActionValidationError("Invalid device payload")
+
+        validated = self._validate_device_identity(payload, require_id=True)
+        validated["state"] = self._normalize_state(validated["type"], validated["state"])
+
+        with self._lock:
+            if self._find(validated["id"]):
+                raise DeviceActionValidationError(f'Device with id "{validated["id"]}" already exists', 409)
+            self._devices.append(validated)
+            self._persist()
+            created_device = deepcopy(validated)
+
+        self._broadcast_update(created_device)
+        return created_device
+
+    def update_device(self, device_id: str, payload: dict):
+        if not isinstance(payload, dict):
+            raise DeviceActionValidationError("Invalid device payload")
+
+        validated = self._validate_device_identity(payload, require_id=False)
+        validated["state"] = self._normalize_state(validated["type"], validated["state"])
+
+        with self._lock:
+            device = self._find(device_id)
+            if not device:
+                raise DeviceActionValidationError(f"Unknown device: {device_id}", 404)
+
+            device["name"] = validated["name"]
+            device["type"] = validated["type"]
+            device["state"] = validated["state"]
+            if "topic" in validated:
+                device["topic"] = validated["topic"]
+            else:
+                device.pop("topic", None)
+
+            self._persist()
+            updated_device = deepcopy(device)
+
+        self._broadcast_update(updated_device)
+        return updated_device
+
+    def delete_device(self, device_id: str):
+        with self._lock:
+            index = next((idx for idx, item in enumerate(self._devices) if item.get("id") == device_id), -1)
+            if index < 0:
+                raise DeviceActionValidationError(f"Unknown device: {device_id}", 404)
+
+            removed_device = deepcopy(self._devices.pop(index))
+            self._persist()
+
+        self._broadcast_update({"id": device_id, "_deleted": True})
+        return removed_device
+
     def apply_action(self, device_id: str, payload: dict):
         with self._lock:
             device = self._find(device_id)

--- a/server/main.py
+++ b/server/main.py
@@ -77,3 +77,27 @@ async def post_device_state(device_id: str, payload: dict):
         return DEVICE_SERVICE.update_state(device_id, payload or {})
     except DeviceActionValidationError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+
+@app.post("/api/admin/devices")
+async def post_admin_device(payload: dict):
+    try:
+        return DEVICE_SERVICE.create_device(payload or {})
+    except DeviceActionValidationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+
+@app.put("/api/admin/devices/{device_id}")
+async def put_admin_device(device_id: str, payload: dict):
+    try:
+        return DEVICE_SERVICE.update_device(device_id, payload or {})
+    except DeviceActionValidationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+
+@app.delete("/api/admin/devices/{device_id}")
+async def delete_admin_device(device_id: str):
+    try:
+        return DEVICE_SERVICE.delete_device(device_id)
+    except DeviceActionValidationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc

--- a/server/test_device_service_json.py
+++ b/server/test_device_service_json.py
@@ -85,3 +85,60 @@ def test_subscribe_stream_receives_device_updates(tmp_path: Path):
         await stream.aclose()
 
     asyncio.run(run_scenario())
+
+
+def test_create_update_delete_device(tmp_path: Path):
+    devices_path = tmp_path / "devices.json"
+    devices_path.write_text("[]", encoding="utf-8")
+    service = DeviceService(devices_path)
+
+    created = service.create_device(
+        {
+            "id": "desk-light",
+            "name": "Desk Light",
+            "type": "switch",
+            "topic": "roompi/devices/desk-light/state",
+            "state": {"on": False},
+        }
+    )
+    assert created["id"] == "desk-light"
+    assert created["state"]["on"] is False
+
+    updated = service.update_device(
+        "desk-light",
+        {
+            "name": "Desk Light Updated",
+            "type": "dimmer",
+            "state": {"level": 65},
+        },
+    )
+    assert updated["type"] == "dimmer"
+    assert updated["state"]["level"] == 65
+    assert "topic" not in updated
+
+    removed = service.delete_device("desk-light")
+    assert removed["id"] == "desk-light"
+    assert service.list_devices() == []
+
+
+def test_delete_device_broadcasts_deleted_event(tmp_path: Path):
+    devices_path = tmp_path / "devices.json"
+    devices_path.write_text(
+        json.dumps([{"id": "lamp", "name": "Lamp", "type": "switch", "state": {"on": False}}]),
+        encoding="utf-8",
+    )
+    service = DeviceService(devices_path)
+
+    async def run_scenario():
+        stream = service.subscribe()
+        first_message_task = asyncio.create_task(stream.__anext__())
+
+        await asyncio.sleep(0)
+        service.delete_device("lamp")
+        update = await asyncio.wait_for(first_message_task, timeout=1.0)
+
+        assert update["id"] == "lamp"
+        assert update["_deleted"] is True
+        await stream.aclose()
+
+    asyncio.run(run_scenario())


### PR DESCRIPTION
### Motivation
- Provide administrators the ability to add, edit and remove devices from the admin UI instead of editing `devices.json` by hand.
- Validate device payloads and normalize type-specific `state` to avoid invalid device entries being persisted.

### Description
- Implemented `create_device`, `update_device` and `delete_device` with payload validation and state normalization in `server/device_service_py.py`, and broadcast updates (including a deletion event with `_deleted: true`).
- Added admin API endpoints `POST /api/admin/devices`, `PUT /api/admin/devices/{device_id}` and `DELETE /api/admin/devices/{device_id}` in `server/main.py` that map to the new service methods and return appropriate HTTP errors on validation failures.
- Replaced the placeholder admin panel with a full CRUD UI in `client/src/views/AdminPanel.vue` that supports add/edit/delete and displays success/error messages, and updated `client/src/views/Devices.vue` to remove devices when a deletion SSE (`_deleted`) is received.
- Added tests in `server/test_device_service_json.py` for create/update/delete flows and for broadcasting a deleted event, and documented the new admin endpoints in `server/README.md`.

### Testing
- Ran `pytest -q` in `server` and all tests passed (`12 passed`).
- Ran `npm test` in `client` and the client test suite passed (all client tests succeeded).
- An attempted `npm test -- --run` invocation failed due to an unsupported `--run` flag for `node --test`, and the plain `npm test` run was used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa9f740b48331b10b8e7e46599f22)