### PR TITLE
Add HTTPS termination and reverse proxy support in frontend Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,45 @@ W repo są gotowe pliki Dockera dla backendu i frontendu oraz `docker-compose.ym
 docker compose up --build -d
 ```
 
-- Frontend: `http://localhost:80`
-- Backend API: `http://localhost:3000`
+- Frontend: `https://localhost` (oraz przekierowanie z `http://localhost`)
+- Backend API (przez reverse proxy): `https://localhost/api`
+- Backend API (bezpośrednio): `http://localhost:3000`
+
+### HTTPS + reverse proxy (Nginx)
+
+Frontendowy kontener Nginx działa jako reverse proxy dla backendu na ścieżce `/api/*` i terminates TLS na porcie `443`.
+
+1. Utwórz katalog certyfikatów:
+
+```bash
+mkdir -p certs certbot/www
+```
+
+2. Dodaj certyfikat i klucz do `./certs`:
+
+- `certs/fullchain.pem`
+- `certs/privkey.pem`
+
+Dla testów lokalnych możesz użyć self-signed cert:
+
+```bash
+openssl req -x509 -nodes -newkey rsa:2048 \
+  -keyout certs/privkey.pem \
+  -out certs/fullchain.pem \
+  -days 365 -subj "/CN=localhost"
+```
+
+3. Uruchom kontenery:
+
+```bash
+docker compose up --build -d
+```
+
+Opcjonalne zmienne środowiskowe:
+
+- `SERVER_NAME` (domyślnie `_`)
+- `SSL_CERT_PATH` (domyślnie `/etc/nginx/certs/fullchain.pem`)
+- `SSL_CERT_KEY_PATH` (domyślnie `/etc/nginx/certs/privkey.pem`)
 
 ### Zatrzymanie
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -16,4 +16,4 @@ ENV API_PORT=3000
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
 
-EXPOSE 80
+EXPOSE 80 443

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,6 +1,28 @@
 server {
     listen 80;
-    server_name _;
+    listen [::]:80;
+    server_name ${SERVER_NAME:-_};
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name ${SERVER_NAME:-_};
+
+    ssl_certificate ${SSL_CERT_PATH:-/etc/nginx/certs/fullchain.pem};
+    ssl_certificate_key ${SSL_CERT_KEY_PATH:-/etc/nginx/certs/privkey.pem};
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,13 @@ services:
     environment:
       - API_HOST=${API_HOST:-backend}
       - API_PORT=${API_PORT:-3000}
+      - SERVER_NAME=${SERVER_NAME:-_}
+      - SSL_CERT_PATH=${SSL_CERT_PATH:-/etc/nginx/certs/fullchain.pem}
+      - SSL_CERT_KEY_PATH=${SSL_CERT_KEY_PATH:-/etc/nginx/certs/privkey.pem}
     ports:
       - "80:80"
+      - "443:443"
+    volumes:
+      - ./certs:/etc/nginx/certs:ro
+      - ./certbot/www:/var/www/certbot:ro
     restart: unless-stopped


### PR DESCRIPTION
### Motivation

- Provide TLS termination for the frontend and serve the SPA over HTTPS with a secure reverse proxy to the backend API.

### Description

- Add a TLS-capable Nginx template in `client/nginx.conf` with an HTTP -> HTTPS redirect, ACME challenge location, and a `443` server block that proxies `/api/` to the backend.
- Expose port `443` in `client/Dockerfile` by changing `EXPOSE 80` to `EXPOSE 80 443` so the image advertises HTTPS support.
- Update `docker-compose.yml` frontend service to publish `443:443`, pass `SERVER_NAME`, `SSL_CERT_PATH`, and `SSL_CERT_KEY_PATH` environment variables, and mount `./certs` and `./certbot/www` into the container for certificate and ACME challenge files.
- Document the HTTPS + reverse proxy setup and a local self-signed certificate example in `README.md` and update the URLs to reference `https://localhost` and `https://localhost/api`.

### Testing

- Attempted to validate the Compose file with `docker compose config`, but the check failed in this environment because `docker` is not installed.
- No unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaabcafce0833192bcc2110345496e)