### PR TITLE
Fix nginx SSL certificate paths in frontend config

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -17,8 +17,8 @@ server {
     listen [::]:443 ssl;
     server_name ${SERVER_NAME:-_};
 
-    ssl_certificate ${SSL_CERT_PATH:-/etc/nginx/certs/fullchain.pem};
-    ssl_certificate_key ${SSL_CERT_KEY_PATH:-/etc/nginx/certs/privkey.pem};
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:10m;
     ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
### Motivation
- The nginx config used shell-style `${VAR:-default}` interpolation which nginx does not expand, so the TLS directives needed static file paths to reliably locate certificates.

### Description
- Replaced `ssl_certificate ${SSL_CERT_PATH:-/etc/nginx/certs/fullchain.pem};` with `ssl_certificate /etc/nginx/certs/fullchain.pem;` and `ssl_certificate_key ${SSL_CERT_KEY_PATH:-/etc/nginx/certs/privkey.pem};` with `ssl_certificate_key /etc/nginx/certs/privkey.pem;` in `client/nginx.conf` and committed the change.

### Testing
- Attempted to rebuild the frontend with `docker compose build frontend`, but the build could not run here because `docker` is not installed (`/bin/bash: line 1: docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaaec6454c833189ca0292a727c4ad)