### PR TITLE
Prevent rsync from overwriting service data and set static TLS paths in nginx

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,15 @@ jobs:
           rsync -a --delete \
             --exclude ".git" \
             --exclude "node_modules" \
+            --exclude='certbot/' \
+            --exclude "certbot/www/" \
+            --exclude "certbot/conf/" \
+            --exclude "homeassistant/" \
+            --exclude "mosquitto/" \
+            --exclude "portainer/" \
+            --exclude "volumes/" \
+            --exclude "docker-data/" \
+            --exclude "runtime/" \
             ./ /home/michalx106/srv/RaspberryPiServer2/
 
       - name: Build only backend and frontend

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -17,8 +17,8 @@ server {
     listen [::]:443 ssl;
     server_name ${SERVER_NAME:-_};
 
-    ssl_certificate ${SSL_CERT_PATH:-/etc/nginx/certs/fullchain.pem};
-    ssl_certificate_key ${SSL_CERT_KEY_PATH:-/etc/nginx/certs/privkey.pem};
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:10m;
     ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
### Motivation
- Avoid copying or overwriting runtime/service-specific data during deploys and ensure nginx uses the expected certificate files on the host.

### Description
- Added multiple `--exclude` entries to `.github/workflows/deploy.yml` to keep `certbot/`, `homeassistant/`, `mosquitto/`, `portainer/`, `volumes/`, `docker-data/`, `runtime/` and related subpaths out of the rsync sync to the Raspberry Pi, while keeping the job focused on building and restarting only the `backend` and `frontend` services.
- Updated `client/nginx.conf` to use explicit certificate file paths `/etc/nginx/certs/fullchain.pem` and `/etc/nginx/certs/privkey.pem` instead of environment-variable placeholders.

### Testing
- No automated unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaaec6454c833189ca0292a727c4ad)