### PR TITLE
Update frontend TLS mounts and nginx proxy config

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,42 +1,20 @@
 server {
     listen 80;
-    listen [::]:80;
-    server_name ${SERVER_NAME:-_};
-
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
-
-    location / {
-        return 301 https://$host$request_uri;
-    }
+    return 301 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl;
-    listen [::]:443 ssl;
-    server_name ${SERVER_NAME:-_};
 
     ssl_certificate /etc/nginx/certs/fullchain.pem;
     ssl_certificate_key /etc/nginx/certs/privkey.pem;
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:10m;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_prefer_server_ciphers off;
-
-    root /usr/share/nginx/html;
-    index index.html;
 
     location / {
-        try_files $uri $uri/ /index.html;
+        root /usr/share/nginx/html;
+        index index.html;
     }
 
-    location /api/ {
-        proxy_pass http://${API_HOST}:${API_PORT};
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+    location /api {
+        proxy_pass http://roompi-backend:3000;
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,6 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./certs:/etc/nginx/certs:ro
-      - ./certbot/www:/var/www/certbot:ro
+      - ./certs/fullchain.pem:/etc/nginx/certs/fullchain.pem:ro
+      - ./certs/privkey.pem:/etc/nginx/certs/privkey.pem:ro
     restart: unless-stopped


### PR DESCRIPTION
### Motivation
- Ensure the frontend nginx uses the specific TLS files instead of mounting the whole `certs` dir and simplify the HTTP->HTTPS redirect behavior.
- Route API requests from the frontend directly to the backend container and remove unused certbot/ACME and complex proxy header plumbing for the embedded nginx config.

### Description
- Updated `docker-compose.yml` `frontend` service to mount `./certs/fullchain.pem` and `./certs/privkey.pem` into `/etc/nginx/certs/` as read-only files instead of mounting the entire `./certs` directory.
- Simplified `client/nginx.conf` to redirect all HTTP (`listen 80`) to HTTPS and serve static files from `/usr/share/nginx/html` on port 443 with `ssl_certificate` and `ssl_certificate_key` pointing to `/etc/nginx/certs/`.
- Changed API proxy to `location /api { proxy_pass http://roompi-backend:3000; }` and removed the ACME challenge, IPv6 listen directives, and the previous `try_files`/proxy header block.
- Changes were saved and committed for the two modified files `docker-compose.yml` and `client/nginx.conf`.

### Testing
- Verified the file edits by printing the updated files with `sed`/`nl`, which showed the intended changes and succeeded.
- Attempted to run `docker compose config` to validate the compose file, but it failed because Docker is not available in the environment (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab27324888331b1b8d8a54de31e0b)