### PR TITLE
Zabezpiecz /api/admin/* nagłówkiem X-Admin-Token

### DIFF
--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -37,8 +37,11 @@ const getCredentials = () => {
   return {
     username: adminCredentials.username ?? '',
     password: adminCredentials.password ?? '',
+    token: adminCredentials.token ?? '',
   }
 }
+
+export const getAdminApiToken = () => getCredentials().token
 
 export const useAdminAuth = () => {
   const login = ({ username, password }) => {

--- a/client/src/config/adminCredentials.json
+++ b/client/src/config/adminCredentials.json
@@ -1,4 +1,5 @@
 {
   "username": "michalx106",
-  "password": "Kowies1234"
+  "password": "Kowies1234",
+  "token": "Kowies1234"
 }

--- a/client/src/views/AdminPanel.vue
+++ b/client/src/views/AdminPanel.vue
@@ -101,6 +101,7 @@
 import axios from 'axios'
 import { onMounted, reactive, ref } from 'vue'
 import { RouterLink } from 'vue-router'
+import { getAdminApiToken } from '../auth'
 
 const devices = ref([])
 const errorMessage = ref('')
@@ -133,6 +134,12 @@ const fetchDevices = async () => {
   const { data } = await axios.get('/api/devices')
   devices.value = Array.isArray(data) ? data : []
 }
+
+const getAdminRequestConfig = () => ({
+  headers: {
+    'X-Admin-Token': getAdminApiToken(),
+  },
+})
 
 const buildPayload = () => {
   const payload = {
@@ -173,10 +180,10 @@ const saveDevice = async () => {
     const payload = buildPayload()
 
     if (editingDeviceId.value) {
-      await axios.put(`/api/admin/devices/${editingDeviceId.value}`, payload)
+      await axios.put(`/api/admin/devices/${editingDeviceId.value}`, payload, getAdminRequestConfig())
       successMessage.value = 'Zapisano zmiany urządzenia.'
     } else {
-      await axios.post('/api/admin/devices', payload)
+      await axios.post('/api/admin/devices', payload, getAdminRequestConfig())
       successMessage.value = 'Dodano nowe urządzenie.'
     }
 
@@ -211,7 +218,7 @@ const removeDevice = async (device) => {
   successMessage.value = ''
 
   try {
-    await axios.delete(`/api/admin/devices/${device.id}`)
+    await axios.delete(`/api/admin/devices/${device.id}`, getAdminRequestConfig())
     if (editingDeviceId.value === device.id) {
       resetForm()
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - MQTT_DEVICE_TOPIC_PREFIX=roompi/devices
       - MQTT_USERNAME=hauser
       - MQTT_PASSWORD=Kowies1234
+      - ADMIN_API_TOKEN=Kowies1234
     ports:
       - "3000:3000"
     volumes:

--- a/server/README.md
+++ b/server/README.md
@@ -30,6 +30,7 @@ uvicorn main:app --host 0.0.0.0 --port 3000
 - `MQTT_DEVICE_TOPIC_PREFIX` (domyślnie `roompi/devices`)
 - `MQTT_USERNAME` (opcjonalnie, np. `hauser`)
 - `MQTT_PASSWORD` (opcjonalnie, hasło do brokera)
+- `ADMIN_API_TOKEN` (wymagany do wszystkich endpointów `/api/admin/*`, przekazywany w nagłówku `X-Admin-Token`)
 
 ## API
 
@@ -39,9 +40,9 @@ uvicorn main:app --host 0.0.0.0 --port 3000
 - `GET /api/devices`
 - `POST /api/devices/{id}/actions`
 - `POST /api/devices/{id}/state` (aktualizacja stanu sensora)
-- `POST /api/admin/devices` (dodanie urządzenia)
-- `PUT /api/admin/devices/{id}` (edycja urządzenia)
-- `DELETE /api/admin/devices/{id}` (usunięcie urządzenia)
+- `POST /api/admin/devices` (dodanie urządzenia, wymaga `X-Admin-Token`)
+- `PUT /api/admin/devices/{id}` (edycja urządzenia, wymaga `X-Admin-Token`)
+- `DELETE /api/admin/devices/{id}` (usunięcie urządzenia, wymaga `X-Admin-Token`)
 
 ## Historia metryk
 

--- a/server/config_py.py
+++ b/server/config_py.py
@@ -18,3 +18,4 @@ MQTT_SENSOR_TOPIC_PREFIX = os.environ.get("MQTT_SENSOR_TOPIC_PREFIX", "roompi/se
 MQTT_DEVICE_TOPIC_PREFIX = os.environ.get("MQTT_DEVICE_TOPIC_PREFIX", "roompi/devices")
 MQTT_USERNAME = os.environ.get("MQTT_USERNAME")
 MQTT_PASSWORD = os.environ.get("MQTT_PASSWORD")
+ADMIN_API_TOKEN = os.environ.get("ADMIN_API_TOKEN")

--- a/server/main.py
+++ b/server/main.py
@@ -3,16 +3,26 @@ from __future__ import annotations
 import asyncio
 import json
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
 from device_service_py import DEVICE_SERVICE, DeviceActionValidationError
 from metrics_service_py import gather_metrics, metrics_history, sample_loop, subscribe
 from mqtt_bridge_py import MQTT_BRIDGE
+from config_py import ADMIN_API_TOKEN
 
 app = FastAPI(title="Raspberry Pi Python Backend")
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
+
+
+def verify_admin_token(x_admin_token: str | None = Header(default=None)) -> None:
+    configured_token = ADMIN_API_TOKEN
+    if not configured_token:
+        raise HTTPException(status_code=503, detail="ADMIN_API_TOKEN is not configured on the server.")
+
+    if x_admin_token != configured_token:
+        raise HTTPException(status_code=401, detail="Unauthorized admin token.")
 
 
 @app.on_event("startup")
@@ -80,7 +90,7 @@ async def post_device_state(device_id: str, payload: dict):
 
 
 @app.post("/api/admin/devices")
-async def post_admin_device(payload: dict):
+async def post_admin_device(payload: dict, _: None = Depends(verify_admin_token)):
     try:
         return DEVICE_SERVICE.create_device(payload or {})
     except DeviceActionValidationError as exc:
@@ -88,7 +98,7 @@ async def post_admin_device(payload: dict):
 
 
 @app.put("/api/admin/devices/{device_id}")
-async def put_admin_device(device_id: str, payload: dict):
+async def put_admin_device(device_id: str, payload: dict, _: None = Depends(verify_admin_token)):
     try:
         return DEVICE_SERVICE.update_device(device_id, payload or {})
     except DeviceActionValidationError as exc:
@@ -96,7 +106,7 @@ async def put_admin_device(device_id: str, payload: dict):
 
 
 @app.delete("/api/admin/devices/{device_id}")
-async def delete_admin_device(device_id: str):
+async def delete_admin_device(device_id: str, _: None = Depends(verify_admin_token)):
     try:
         return DEVICE_SERVICE.delete_device(device_id)
     except DeviceActionValidationError as exc:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.30.6
 psutil==6.0.0
 pytest==8.3.2
 paho-mqtt==2.1.0
+httpx==0.27.2

--- a/server/test_admin_auth_py.py
+++ b/server/test_admin_auth_py.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+
+import main
+
+
+def test_admin_endpoints_require_token(monkeypatch):
+    monkeypatch.setattr(main, "ADMIN_API_TOKEN", "secret-token")
+    monkeypatch.setattr(main.DEVICE_SERVICE, "create_device", lambda payload: payload)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/api/admin/devices",
+        json={"id": "desk-light", "name": "Desk Light", "type": "switch", "state": {"on": False}},
+    )
+
+    assert response.status_code == 401
+
+
+def test_admin_endpoints_accept_valid_token(monkeypatch):
+    monkeypatch.setattr(main, "ADMIN_API_TOKEN", "secret-token")
+    monkeypatch.setattr(main.DEVICE_SERVICE, "create_device", lambda payload: payload)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/api/admin/devices",
+        headers={"X-Admin-Token": "secret-token"},
+        json={"id": "desk-light-auth", "name": "Desk Light", "type": "switch", "state": {"on": False}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "desk-light-auth"


### PR DESCRIPTION
### Motivation
- Zabezpieczyć wszystkie endpointy administracyjne przed nieautoryzowanym dostępem przez wymaganie tokenu w nagłówku `X-Admin-Token`.
- Umożliwić łatwą konfigurację tokenu po stronie serwera przez zmienną środowiskową `ADMIN_API_TOKEN` oraz przesyłanie go z panelu administracyjnego frontendu.

### Description
- Dodano zmienną konfiguracyjną `ADMIN_API_TOKEN` w `server/config_py.py` i dokumentację jej użycia w `server/README.md`.
- Dodano walidator `verify_admin_token` w `server/main.py` który zwraca `503` gdy `ADMIN_API_TOKEN` nie jest ustawiony i `401` przy niepoprawnym tokenie, oraz podpięto go jako dependency do `POST/PUT/DELETE` na ścieżkach `/api/admin/devices`.
- Zaktualizowano frontend: dodano `getAdminApiToken` w `client/src/auth.js`, zapisano token w `client/src/config/adminCredentials.json` i dołączono nagłówek `X-Admin-Token` do żądań admin API w `client/src/views/AdminPanel.vue`.
- Dodano testy `server/test_admin_auth_py.py`, zaktualizowano `server/requirements.txt` o `httpx`, oraz ustawiono `ADMIN_API_TOKEN` w `docker-compose.yml`.

### Testing
- Zainstalowano testowy klient HTTP przez `pip install httpx==0.27.2` to umożliwiło uruchomienie `fastapi.testclient`.
- Uruchomiono testy jednostkowe w katalogu serwera poleceniem `cd server && pytest -q` i wszystkie testy przeszły pomyślnie (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabd2dae148331b68aca75183de829)