### PR TITLE
Add backend healthcheck and atomic devices.json writes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ services:
       - "3000:3000"
     volumes:
       - ./server/devices.json:/app/devices.json
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:3000/health', timeout=2)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
 
   frontend:
@@ -24,7 +30,8 @@ services:
       context: ./client
     container_name: roompi-frontend
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     environment:
       - API_HOST=${API_HOST:-backend}
       - API_PORT=${API_PORT:-3000}

--- a/server/device_service_py.py
+++ b/server/device_service_py.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
@@ -34,8 +35,10 @@ class DeviceService:
                 self._persist()
 
     def _persist(self):
-        serialized = json.dumps(self._devices, ensure_ascii=False, indent=2)
-        self._devices_path.write_text(serialized + "\n", encoding="utf-8")
+        serialized = json.dumps(self._devices, ensure_ascii=False, indent=2) + "\n"
+        temp_path = self._devices_path.with_name(f"{self._devices_path.name}.tmp")
+        temp_path.write_text(serialized, encoding="utf-8")
+        os.replace(temp_path, self._devices_path)
 
     def list_devices(self):
         with self._lock:

--- a/server/main.py
+++ b/server/main.py
@@ -36,6 +36,11 @@ async def shutdown_event():
     MQTT_BRIDGE.stop()
 
 
+
+@app.get("/health")
+async def healthcheck():
+    return {"status": "ok"}
+
 @app.get("/api/metrics/current")
 async def get_metrics_current():
     return gather_metrics()

--- a/server/test_admin_auth_py.py
+++ b/server/test_admin_auth_py.py
@@ -29,3 +29,12 @@ def test_admin_endpoints_accept_valid_token(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()["id"] == "desk-light-auth"
+
+
+def test_healthcheck_endpoint():
+    client = TestClient(main.app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/server/test_device_service_json.py
+++ b/server/test_device_service_json.py
@@ -142,3 +142,18 @@ def test_delete_device_broadcasts_deleted_event(tmp_path: Path):
         await stream.aclose()
 
     asyncio.run(run_scenario())
+
+
+def test_persist_uses_atomic_replace_without_temp_leak(tmp_path: Path):
+    devices_path = tmp_path / "devices.json"
+    devices_path.write_text(
+        json.dumps([{"id": "lamp", "name": "Lamp", "type": "switch", "state": {"on": False}}]),
+        encoding="utf-8",
+    )
+
+    service = DeviceService(devices_path)
+    service.apply_action("lamp", {"action": "toggle"})
+
+    persisted = json.loads(devices_path.read_text(encoding="utf-8"))
+    assert persisted[0]["state"]["on"] is True
+    assert not (tmp_path / "devices.json.tmp").exists()


### PR DESCRIPTION
### Motivation
- Ensure the backend has a simple liveness endpoint so Docker Compose can perform a healthcheck (`/health`).
- Prevent partial/corrupt `devices.json` writes by making persistence atomic. 
- Make the frontend wait for a healthy backend instance before starting to avoid race conditions on service startup.

### Description
- Added a `GET /health` endpoint that returns `{"status": "ok"}` in `server/main.py`.
- Configured a Docker Compose `healthcheck` for the `backend` service and changed `frontend.depends_on` to use `condition: service_healthy` in `docker-compose.yml`.
- Switched `DeviceService._persist()` in `server/device_service_py.py` to write to a temporary file and atomically replace the target with `os.replace()` to avoid partial writes.
- Added tests: `server/test_admin_auth_py.py` includes `test_healthcheck_endpoint` and `server/test_device_service_json.py` includes `test_persist_uses_atomic_replace_without_temp_leak`.

### Testing
- Ran `cd server && pytest -q test_device_service_json.py` and it passed (`7 passed`).
- Ran `cd server && pytest -q test_device_service_json.py test_admin_auth_py.py` and collection failed because `httpx` is not installed in the environment, causing `starlette.testclient` to raise a `RuntimeError` (test failure is due to missing test dependency, not the code changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabebc34dc83318159a17e1e82dae9)