### PR TITLE
Dodaj JWT do logowania panelu administratora

### DIFF
--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -1,19 +1,37 @@
+import axios from 'axios'
 import { computed, ref } from 'vue'
-import adminCredentials from './config/adminCredentials.json'
 
-const SESSION_STORAGE_KEY = 'roompi-admin-authenticated'
+const AUTH_STORAGE_KEY = 'roompi-admin-auth'
 
-const isAuthenticated = ref(false)
+const authState = ref({
+  isAuthenticated: false,
+  token: '',
+})
 
 const isBrowserEnvironment =
   typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined'
 
 const readStoredState = () => {
   if (!isBrowserEnvironment) {
-    return false
+    return { isAuthenticated: false, token: '' }
   }
 
-  return window.sessionStorage.getItem(SESSION_STORAGE_KEY) === 'true'
+  try {
+    const raw = window.sessionStorage.getItem(AUTH_STORAGE_KEY)
+    if (!raw) {
+      return { isAuthenticated: false, token: '' }
+    }
+
+    const parsed = JSON.parse(raw)
+    const token = typeof parsed?.token === 'string' ? parsed.token : ''
+
+    return {
+      isAuthenticated: Boolean(token),
+      token,
+    }
+  } catch {
+    return { isAuthenticated: false, token: '' }
+  }
 }
 
 const persistState = (value) => {
@@ -21,43 +39,58 @@ const persistState = (value) => {
     return
   }
 
-  window.sessionStorage.setItem(SESSION_STORAGE_KEY, value ? 'true' : 'false')
-}
-
-isAuthenticated.value = readStoredState()
-
-const getCredentials = () => {
-  if (!adminCredentials || typeof adminCredentials !== 'object') {
-    return {
-      username: '',
-      password: '',
-    }
+  if (!value.token) {
+    window.sessionStorage.removeItem(AUTH_STORAGE_KEY)
+    return
   }
 
-  return {
-    username: adminCredentials.username ?? '',
-    password: adminCredentials.password ?? '',
-  }
+  window.sessionStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(value))
 }
+
+const applyAuthHeader = (token) => {
+  if (token) {
+    axios.defaults.headers.common.Authorization = `Bearer ${token}`
+    return
+  }
+
+  delete axios.defaults.headers.common.Authorization
+}
+
+authState.value = readStoredState()
+applyAuthHeader(authState.value.token)
 
 export const useAdminAuth = () => {
-  const login = ({ username, password }) => {
-    const credentials = getCredentials()
-    const loginSucceeded =
-      username === credentials.username && password === credentials.password
+  const login = async ({ username, password }) => {
+    const { data } = await axios.post('/api/admin/login', {
+      username,
+      password,
+    })
 
-    isAuthenticated.value = loginSucceeded
-    persistState(loginSucceeded)
-    return loginSucceeded
+    const token = typeof data?.accessToken === 'string' ? data.accessToken : ''
+
+    authState.value = {
+      isAuthenticated: Boolean(token),
+      token,
+    }
+
+    persistState(authState.value)
+    applyAuthHeader(token)
+
+    return authState.value.isAuthenticated
   }
 
   const logout = () => {
-    isAuthenticated.value = false
-    persistState(false)
+    authState.value = {
+      isAuthenticated: false,
+      token: '',
+    }
+
+    persistState(authState.value)
+    applyAuthHeader('')
   }
 
   return {
-    isAuthenticated: computed(() => isAuthenticated.value),
+    isAuthenticated: computed(() => authState.value.isAuthenticated),
     login,
     logout,
   }

--- a/client/src/config/adminCredentials.json
+++ b/client/src/config/adminCredentials.json
@@ -1,4 +1,0 @@
-{
-  "username": "michalx106",
-  "password": "Kowies1234"
-}

--- a/client/src/views/AdminLogin.vue
+++ b/client/src/views/AdminLogin.vue
@@ -43,21 +43,25 @@ const router = useRouter()
 const route = useRoute()
 const { login } = useAdminAuth()
 
-const submitLogin = () => {
+const submitLogin = async () => {
   errorMessage.value = ''
 
-  const isSuccess = login({
-    username: username.value,
-    password: password.value,
-  })
+  try {
+    const isSuccess = await login({
+      username: username.value,
+      password: password.value,
+    })
 
-  if (!isSuccess) {
-    errorMessage.value = 'Niepoprawny login lub hasło.'
-    return
+    if (!isSuccess) {
+      errorMessage.value = 'Niepoprawny login lub hasło.'
+      return
+    }
+
+    const redirectPath = typeof route.query.redirect === 'string' ? route.query.redirect : '/admin'
+    router.push(redirectPath)
+  } catch (error) {
+    errorMessage.value = error?.response?.data?.detail ?? 'Niepoprawny login lub hasło.'
   }
-
-  const redirectPath = typeof route.query.redirect === 'string' ? route.query.redirect : '/admin'
-  router.push(redirectPath)
 }
 </script>
 

--- a/server/README.md
+++ b/server/README.md
@@ -30,18 +30,23 @@ uvicorn main:app --host 0.0.0.0 --port 3000
 - `MQTT_DEVICE_TOPIC_PREFIX` (domyślnie `roompi/devices`)
 - `MQTT_USERNAME` (opcjonalnie, np. `hauser`)
 - `MQTT_PASSWORD` (opcjonalnie, hasło do brokera)
+- `ADMIN_USERNAME` (domyślnie `michalx106`)
+- `ADMIN_PASSWORD` (domyślnie `Kowies1234`)
+- `JWT_SECRET` (domyślnie `change-me-in-production` - ustaw własny w produkcji)
+- `JWT_EXPIRE_MINUTES` (domyślnie `120`)
 
 ## API
 
+- `POST /api/admin/login` (zwraca JWT dla admina)
 - `GET /api/metrics/current`
 - `GET /api/metrics/history`
 - `GET /api/metrics/stream` (SSE)
 - `GET /api/devices`
 - `POST /api/devices/{id}/actions`
 - `POST /api/devices/{id}/state` (aktualizacja stanu sensora)
-- `POST /api/admin/devices` (dodanie urządzenia)
-- `PUT /api/admin/devices/{id}` (edycja urządzenia)
-- `DELETE /api/admin/devices/{id}` (usunięcie urządzenia)
+- `POST /api/admin/devices` (dodanie urządzenia, wymaga `Authorization: Bearer <token>`)
+- `PUT /api/admin/devices/{id}` (edycja urządzenia, wymaga `Authorization: Bearer <token>`)
+- `DELETE /api/admin/devices/{id}` (usunięcie urządzenia, wymaga `Authorization: Bearer <token>`)
 
 ## Historia metryk
 

--- a/server/auth_py.py
+++ b/server/auth_py.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from config_py import ADMIN_PASSWORD, ADMIN_USERNAME, JWT_ALGORITHM, JWT_EXPIRE_MINUTES, JWT_SECRET
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def create_access_token(username: str) -> str:
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=JWT_EXPIRE_MINUTES)
+    payload = {
+        "sub": username,
+        "exp": expires_at,
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+
+def authenticate_admin(username: str, password: str) -> str | None:
+    if username != ADMIN_USERNAME or password != ADMIN_PASSWORD:
+        return None
+    return create_access_token(username)
+
+
+def decode_access_token(token: str) -> dict:
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    except jwt.PyJWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Nieprawidłowy lub wygasły token.",
+        ) from exc
+
+    if not isinstance(payload, dict) or not payload.get("sub"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Nieprawidłowy token.",
+        )
+
+    return payload
+
+
+def require_admin(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> str:
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Brak tokenu autoryzacyjnego.",
+        )
+
+    payload = decode_access_token(credentials.credentials)
+    return str(payload["sub"])

--- a/server/config_py.py
+++ b/server/config_py.py
@@ -18,3 +18,9 @@ MQTT_SENSOR_TOPIC_PREFIX = os.environ.get("MQTT_SENSOR_TOPIC_PREFIX", "roompi/se
 MQTT_DEVICE_TOPIC_PREFIX = os.environ.get("MQTT_DEVICE_TOPIC_PREFIX", "roompi/devices")
 MQTT_USERNAME = os.environ.get("MQTT_USERNAME")
 MQTT_PASSWORD = os.environ.get("MQTT_PASSWORD")
+
+ADMIN_USERNAME = os.environ.get("ADMIN_USERNAME", "michalx106")
+ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "Kowies1234")
+JWT_SECRET = os.environ.get("JWT_SECRET", "change-me-in-production")
+JWT_ALGORITHM = "HS256"
+JWT_EXPIRE_MINUTES = int(os.environ.get("JWT_EXPIRE_MINUTES", 120))

--- a/server/main.py
+++ b/server/main.py
@@ -3,16 +3,23 @@ from __future__ import annotations
 import asyncio
 import json
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
+from auth_py import authenticate_admin, require_admin
 from device_service_py import DEVICE_SERVICE, DeviceActionValidationError
 from metrics_service_py import gather_metrics, metrics_history, sample_loop, subscribe
 from mqtt_bridge_py import MQTT_BRIDGE
 
 app = FastAPI(title="Raspberry Pi Python Backend")
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
+
+
+class LoginPayload(BaseModel):
+    username: str
+    password: str
 
 
 @app.on_event("startup")
@@ -24,6 +31,18 @@ async def startup_event():
 @app.on_event("shutdown")
 async def shutdown_event():
     MQTT_BRIDGE.stop()
+
+
+@app.post("/api/admin/login")
+async def post_admin_login(payload: LoginPayload):
+    token = authenticate_admin(payload.username, payload.password)
+    if token is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Niepoprawny login lub hasło.")
+
+    return {
+        "accessToken": token,
+        "tokenType": "Bearer",
+    }
 
 
 @app.get("/api/metrics/current")
@@ -80,7 +99,7 @@ async def post_device_state(device_id: str, payload: dict):
 
 
 @app.post("/api/admin/devices")
-async def post_admin_device(payload: dict):
+async def post_admin_device(payload: dict, _admin_username: str = Depends(require_admin)):
     try:
         return DEVICE_SERVICE.create_device(payload or {})
     except DeviceActionValidationError as exc:
@@ -88,7 +107,7 @@ async def post_admin_device(payload: dict):
 
 
 @app.put("/api/admin/devices/{device_id}")
-async def put_admin_device(device_id: str, payload: dict):
+async def put_admin_device(device_id: str, payload: dict, _admin_username: str = Depends(require_admin)):
     try:
         return DEVICE_SERVICE.update_device(device_id, payload or {})
     except DeviceActionValidationError as exc:
@@ -96,7 +115,7 @@ async def put_admin_device(device_id: str, payload: dict):
 
 
 @app.delete("/api/admin/devices/{device_id}")
-async def delete_admin_device(device_id: str):
+async def delete_admin_device(device_id: str, _admin_username: str = Depends(require_admin)):
     try:
         return DEVICE_SERVICE.delete_device(device_id)
     except DeviceActionValidationError as exc:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.30.6
 psutil==6.0.0
 pytest==8.3.2
 paho-mqtt==2.1.0
+PyJWT==2.9.0

--- a/server/test_auth_py.py
+++ b/server/test_auth_py.py
@@ -1,0 +1,32 @@
+import jwt
+import pytest
+from fastapi import HTTPException
+
+import auth_py
+
+
+def test_authenticate_admin_returns_token_for_valid_credentials(monkeypatch):
+    monkeypatch.setattr(auth_py, "ADMIN_USERNAME", "admin")
+    monkeypatch.setattr(auth_py, "ADMIN_PASSWORD", "secret")
+
+    token = auth_py.authenticate_admin("admin", "secret")
+
+    assert isinstance(token, str)
+    payload = jwt.decode(token, auth_py.JWT_SECRET, algorithms=[auth_py.JWT_ALGORITHM])
+    assert payload["sub"] == "admin"
+
+
+def test_authenticate_admin_rejects_invalid_credentials(monkeypatch):
+    monkeypatch.setattr(auth_py, "ADMIN_USERNAME", "admin")
+    monkeypatch.setattr(auth_py, "ADMIN_PASSWORD", "secret")
+
+    token = auth_py.authenticate_admin("admin", "bad")
+
+    assert token is None
+
+
+def test_decode_access_token_raises_for_invalid_token():
+    with pytest.raises(HTTPException) as exc:
+        auth_py.decode_access_token("invalid-token")
+
+    assert exc.value.status_code == 401


### PR DESCRIPTION
### Motivation
- Zabezpieczyć endpointy administracyjne i zastąpić twardo zakodowane sprawdzanie login/hasło na front-endzie bezpiecznym mechanizmem tokenowym.
- Umożliwić frontendowi otrzymanie i przesyłanie tokena JWT przy logowaniu, aby autoryzować operacje administracyjne.
- Pozwolić na konfigurację danych admina i parametrów JWT przez zmienne środowiskowe dla łatwiejszego wdrożenia.

### Description
- Dodano moduł autoryzacji JWT `server/auth_py.py` z funkcjami `create_access_token`, `authenticate_admin`, `decode_access_token` oraz dependency `require_admin` do ochrony endpointów.
- Dodano endpoint logowania `POST /api/admin/login` w `server/main.py`, który zwraca `accessToken` i `tokenType`, oraz podłączono `require_admin` do `POST/PUT/DELETE /api/admin/devices`.
- Przeniesiono ustawienia admina i JWT do konfiguracji (`server/config_py.py`) jako zmienne środowiskowe: `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `JWT_SECRET`, `JWT_EXPIRE_MINUTES`.
- Zmiany frontendu: `client/src/auth.js` wysyła żądanie do `/api/admin/login`, zapisuje token JWT w `sessionStorage` i automatycznie ustawia nagłówek `Authorization: Bearer <token>`, oraz zaktualizowano `client/src/views/AdminLogin.vue` do asynchronicznego logowania i obsługi błędów; usunięto `client/src/config/adminCredentials.json`.
- Dodano `PyJWT==2.9.0` do `server/requirements.txt`, testy jednostkowe `server/test_auth_py.py` oraz uaktualniono dokumentację `server/README.md` o nowe zmienne i wymagania Bearer token.

### Testing
- Uruchomiono `cd server && pytest -q` and the test suite passed with `15 passed`.
- Uruchomiono frontend tests with `cd client && npm test` and they passed with `6 passed`.
- A prior attempt `cd client && npm test -- --run` failed due to an incorrect Node test flag (`node: bad option: --run`), after which the correct `npm test` was run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac79538c48331884580247c47b647)